### PR TITLE
Enhance UploadDocumentChild and ModalBillingMT components

### DIFF
--- a/src/components/atoms/UploadDocumentChild/UploadDocumentChild.tsx
+++ b/src/components/atoms/UploadDocumentChild/UploadDocumentChild.tsx
@@ -9,15 +9,16 @@ type Props = {
   onDelete: () => void;
   linkFile: string;
   nameFile: string;
+  fullName?: boolean;
 };
 
 export default function UploadDocumentChild(props: Props) {
-  const { showTrash, onDelete, linkFile, nameFile } = props;
+  const { showTrash, onDelete, linkFile, nameFile, fullName } = props;
   return (
     <Flex gap={20} align="center" justify="space-between">
       <Button type="text" href={linkFile} target="_blank" style={{ padding: 0 }}>
         <FileArrowDown size={"25px"} />
-        <Text className="nameFile">{shortenFileName(nameFile, 22)}</Text>
+        <Text className="nameFile">{fullName ? nameFile : shortenFileName(nameFile, 22)}</Text>
       </Button>
       {showTrash && (
         <Button

--- a/src/components/molecules/modals/ModalBillingAction/UploadServiceSupport/UploadServiceSupport.tsx
+++ b/src/components/molecules/modals/ModalBillingAction/UploadServiceSupport/UploadServiceSupport.tsx
@@ -252,7 +252,7 @@ const UploadServiceSupport = ({ onClose, journeysData, trId }: IUploadServiceSup
                               <div className={styles.content__doc}>
                                 <Flex vertical>
                                   <p>MT 0</p>
-                                  <em className="descriptionDocument">*Obligatorioasas</em>
+                                  <em className="descriptionDocument">*Obligatorio</em>
                                 </Flex>
                                 <DocumentButton
                                   title={"MT 0"}

--- a/src/components/molecules/modals/ModalBillingMT/ModalBillingMT.tsx
+++ b/src/components/molecules/modals/ModalBillingMT/ModalBillingMT.tsx
@@ -7,13 +7,12 @@ import {
   emptyForm,
   emptyVehicle,
   EvidenceByVehicleForm,
-  IParsedFormValues,
-  IVehicleAPI
+  IParsedFormValues
 } from "./controllers/formbillingmt.types";
 import { useForm, useWatch } from "react-hook-form";
 import FooterButtons from "../ModalBillingAction/FooterButtons/FooterButtons";
 import { DocumentFields } from "./components/DocumentsFields";
-import { getTripDetails, sendFinalizeTrip } from "@/services/trips/trips";
+import { getTripDetails, IGetTripDetails, sendFinalizeTrip } from "@/services/trips/trips";
 
 type PropsModalBillingMT = {
   idTR: string;
@@ -28,7 +27,7 @@ export default function ModalBillingMT(props: Readonly<PropsModalBillingMT>) {
   const { isOpen, onClose, idTrip, messageApi, mode } = props;
   const [isInitialized, setIsInitialized] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [vehicleInfo, setVehicleInfo] = useState<IVehicleAPI>(emptyVehicle);
+  const [vehicleInfo, setVehicleInfo] = useState<IGetTripDetails>(emptyVehicle);
   const [defaultValues, setDefaultValues] = useState<EvidenceByVehicleForm>(emptyForm);
   const [deletedDocs, setDeletedDocs] = useState<string[]>([]);
 
@@ -38,24 +37,26 @@ export default function ModalBillingMT(props: Readonly<PropsModalBillingMT>) {
     });
   const formValues = useWatch({ control });
 
-  function createDefaultValues(vehicle: IVehicleAPI): EvidenceByVehicleForm {
+  function createDefaultValues(vehicle: IGetTripDetails): EvidenceByVehicleForm {
     return {
       plate: vehicle.plate_number,
       idTrip: vehicle.id,
       documents:
         vehicle.MT?.length > 0
-          ? vehicle.MT.map((MTlink, index) => {
+          ? vehicle.MT.map((MT, index) => {
               return {
-                link: MTlink ?? undefined,
+                link: MT.url ?? undefined,
                 file: undefined,
-                docReference: index.toString()
+                docReference: index.toString(),
+                name: MT.name ?? ""
               };
             })
           : [
               {
                 link: undefined,
                 file: undefined,
-                docReference: ""
+                docReference: "",
+                name: ""
               }
             ]
     };
@@ -65,10 +66,11 @@ export default function ModalBillingMT(props: Readonly<PropsModalBillingMT>) {
     try {
       setIsLoading(true);
       const response = await getTripDetails(idTrip);
+      console.log("responseTripDetails", response);
       if (response) {
         setVehicleInfo({
           ...response,
-          MT: response.MT.map((mtItem) => mtItem.url)
+          MT: response.MT
         });
       }
     } catch (error) {
@@ -170,6 +172,20 @@ export default function ModalBillingMT(props: Readonly<PropsModalBillingMT>) {
       reset(newDefaultValues);
     }
   }, [vehicleInfo, reset]);
+
+  useEffect(() => {
+    const allDocsAreEmpty = !formValues.documents || formValues.documents.length === 0;
+
+    if (allDocsAreEmpty) {
+      setValue("documents", [
+        {
+          link: undefined,
+          file: undefined,
+          docReference: ""
+        }
+      ]);
+    }
+  }, [formValues, setValue]);
 
   const isConfirmDisabled = useMemo(() => {
     return areFilesEqual(formValues.documents ?? [], defaultValues.documents ?? []);

--- a/src/components/molecules/modals/ModalBillingMT/components/DocumentsFields.tsx
+++ b/src/components/molecules/modals/ModalBillingMT/components/DocumentsFields.tsx
@@ -51,9 +51,10 @@ export function DocumentFields({
               >
                 <UploadDocumentChild
                   linkFile={document.link}
-                  nameFile={document.link.split("-").pop() ?? ""}
+                  nameFile={document.name || document.link.split("-").pop() || ""}
                   showTrash={mode === "edit"}
                   onDelete={() => internalDeleteDocument(documentIndex)}
+                  fullName
                 />
               </UploadDocumentButton>
             );

--- a/src/components/molecules/modals/ModalBillingMT/controllers/formbillingmt.types.ts
+++ b/src/components/molecules/modals/ModalBillingMT/controllers/formbillingmt.types.ts
@@ -2,6 +2,7 @@ import { FileObject } from "@/components/atoms/UploadDocumentButton/UploadDocume
 
 export interface FileWithLink extends FileObject {
   link?: string;
+  name?: string;
 }
 
 export interface EvidenceByVehicleForm {
@@ -17,7 +18,7 @@ export const emptyForm: EvidenceByVehicleForm = {
     {
       docReference: "",
       file: undefined, // No file uploaded yet
-      aditionalData: undefined // Empty object for additional data
+      name: ""
     }
   ]
 };


### PR DESCRIPTION
- Added fullName prop to UploadDocumentChild for displaying full file names.
- Fixed typo in UploadServiceSupport component's description.
- Updated ModalBillingMT to use IGetTripDetails for vehicle info.
- Improved createDefaultValues function to include document names.
- Adjusted DocumentFields to pass document names to UploadDocumentChild.
- Modified formbillingmt.types to include name property in FileWithLink.