### PR TITLE
Fix/tracking state trip summary

### DIFF
--- a/src/components/molecules/modals/ModalResumeTracking/components/ModalHeader/index.tsx
+++ b/src/components/molecules/modals/ModalResumeTracking/components/ModalHeader/index.tsx
@@ -22,8 +22,8 @@ const ModalHeader: React.FC<ModalHeaderProps> = ({
   defaultStateId,
   showState = true
 }) => {
-  const getState = (stateId: string) => {
-    let state = transferOrderStates.find((f) => f.id === stateId);
+  const getState = (vehicle: VehicleTracking) => {
+    let state = transferOrderStates.find((f) => f.id === vehicle.state_id);
     if (!state) {
       state = transferOrderStates.find((f) => f.id === defaultStateId);
     }
@@ -31,7 +31,7 @@ const ModalHeader: React.FC<ModalHeaderProps> = ({
     return state ? (
       <div className={styles.trackStateContainer}>
         <p className={styles.trackState} style={{ backgroundColor: state.bgColor }}>
-          {state.name}
+          {vehicle.trip_status ?? state.name}
         </p>
       </div>
     ) : null;
@@ -61,7 +61,7 @@ const ModalHeader: React.FC<ModalHeaderProps> = ({
           {vehicle.driver_name ?? ""} - {vehicle.driver_phone ?? ""}
         </Link>
       </div>
-      {showState && getState(vehicle.state_id ?? "")}
+      {showState && getState(vehicle)}
     </div>
   );
 };

--- a/src/components/molecules/modals/ModalResumeTracking/components/ModalVehicleFollowUp/index.tsx
+++ b/src/components/molecules/modals/ModalResumeTracking/components/ModalVehicleFollowUp/index.tsx
@@ -1,12 +1,16 @@
-import { Modal, Flex, Typography, ConfigProvider, Dropdown, Input, MenuProps } from "antd";
-import Link from "next/link";
-import styles from "./ModalVehicleFollowUp.module.scss"; // Ajusta según tu estructura
-import FooterButtons from "../../../ModalBillingAction/FooterButtons/FooterButtons";
-import { VehicleTracking } from "@/types/logistics/tracking/tracking";
-import ModalHeader from "../ModalHeader";
-import { TransferOrdersState } from "@/utils/constants/transferOrdersState";
-import { STATUS } from "@/utils/constants/globalConstants";
 import { useEffect } from "react";
+import { Modal, Flex, Typography, ConfigProvider, Dropdown, Input, MenuProps } from "antd";
+
+import { TransferOrdersState } from "@/utils/constants/transferOrdersState";
+import { TransferOrdersTripState } from "@/utils/constants/transferOrdersState";
+import { STATUS } from "@/utils/constants/globalConstants";
+
+import FooterButtons from "../../../ModalBillingAction/FooterButtons/FooterButtons";
+import ModalHeader from "../ModalHeader";
+
+import { VehicleTracking } from "@/types/logistics/tracking/tracking";
+
+import styles from "./ModalVehicleFollowUp.module.scss"; // Ajusta según tu estructura
 
 const { Text } = Typography;
 const { TextArea } = Input;
@@ -38,29 +42,10 @@ export const ModalVehicleFollowUp: React.FC<ModalVehicleFollowUpProps> = ({
   isLoading,
   tripStatus
 }) => {
-  const items: MenuProps["items"] = [
-    {
-      key: "0f7cccf5-1764-44c6-bb2a-874f419bc8f1",
-      label: "Cargando"
-    },
-    {
-      key: "b9e5ce08-16a7-4880-88a5-ebca7737c55d",
-      label: "En curso"
-    },
-    {
-      key: "780fa2f9-1b89-4d92-83dc-52de4c932056",
-      label: "Descargando"
-    },
-    {
-      key: "9f37afd7-1852-457d-964b-378fa6150471",
-      label: "Detenido"
-    },
-    {
-      key: "73ad61e3-395f-4ae4-8aef-9d24f3f917a9",
-      label: "Stand by"
-    }
-  ];
-  console.log("comments", comment);
+  const items: MenuProps["items"] = TransferOrdersTripState.map((item) => ({
+    key: item.id,
+    label: item.name
+  }));
 
   useEffect(() => {
     if (isOpen) {

--- a/src/components/molecules/modals/ModalResumeTracking/index.tsx
+++ b/src/components/molecules/modals/ModalResumeTracking/index.tsx
@@ -34,6 +34,7 @@ interface InvoiceDetailModalProps {
   isOpen: boolean;
   onClose: () => void;
   idTR: number;
+  refetchNovelty: () => void;
 }
 export const TrackingStepState = [
   {
@@ -56,7 +57,12 @@ export const TrackingStepState = [
   }
 ];
 
-const ModalResumeTracking: FC<InvoiceDetailModalProps> = ({ isOpen, onClose, idTR }) => {
+const ModalResumeTracking: FC<InvoiceDetailModalProps> = ({
+  isOpen,
+  onClose,
+  idTR,
+  refetchNovelty
+}) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [activeKey, setActiveKey] = useState<string>("1");
   const [isModalChangeStatus, setisModalChangeStatus] = useState(false);
@@ -102,11 +108,11 @@ const ModalResumeTracking: FC<InvoiceDetailModalProps> = ({ isOpen, onClose, idT
     };
     setIsLoadingChangeStatus(true);
     try {
-      const response = await updateTripTrackingStatus(finalData);
-      if (response) {
-        message.success(`Cambio de estado realizado correctamente`, 3);
-        await mutate(undefined, { revalidate: true });
-      }
+      await updateTripTrackingStatus(finalData);
+
+      message.success(`Cambio de estado realizado correctamente`, 3);
+      await mutate(undefined, { revalidate: true });
+      refetchNovelty();
     } catch (error: any) {
       message.error(error?.response?.data?.message || "Cambio de estado no realizado", 3);
     } finally {

--- a/src/components/molecules/modals/ModalResumeTracking/index.tsx
+++ b/src/components/molecules/modals/ModalResumeTracking/index.tsx
@@ -254,11 +254,7 @@ const ModalResumeTracking: FC<InvoiceDetailModalProps> = ({ isOpen, onClose, idT
             </div>
           )}
         >
-          <GenerateActionButton
-            onClick={() => {
-              console.log("click");
-            }}
-          />
+          <GenerateActionButton onClick={() => {}} />
         </Dropdown>
       </div>
       <Skeleton loading={isLoading} active>

--- a/src/components/molecules/modals/ModalResumeTracking/index.tsx
+++ b/src/components/molecules/modals/ModalResumeTracking/index.tsx
@@ -12,7 +12,7 @@ import dayjs from "dayjs";
 import "dayjs/locale/es"; // Importar el idioma español
 
 import { updateTripTrackingStatus } from "@/services/logistics/tracking";
-import { TransferOrdersState } from "@/utils/constants/transferOrdersState";
+import { TransferOrdersTripState } from "@/utils/constants/transferOrdersState";
 import { fetcher } from "@/utils/api/api";
 import { formatMoney } from "@/utils/utils";
 
@@ -116,9 +116,11 @@ const ModalResumeTracking: FC<InvoiceDetailModalProps> = ({ isOpen, onClose, idT
   };
 
   const getStateDropdown = (stateId: string) => {
-    let getState = TransferOrdersState.find((f) => f.id === stateId);
+    let getState = TransferOrdersTripState.find((f) => f.id === stateId);
     if (!getState) {
-      getState = TransferOrdersState.find((f) => f.id === "d33e062f-51a5-457e-946e-a45cbbffbf95");
+      getState = TransferOrdersTripState.find(
+        (f) => f.id === "d33e062f-51a5-457e-946e-a45cbbffbf95"
+      );
     }
 
     return (
@@ -265,7 +267,7 @@ const ModalResumeTracking: FC<InvoiceDetailModalProps> = ({ isOpen, onClose, idT
             <UiTab tabs={items} sticky onChange={onChange} />
             <ModalHeader
               vehicle={currentVehicle}
-              transferOrderStates={TransferOrdersState}
+              transferOrderStates={TransferOrdersTripState}
               defaultStateId={STATUS.TR.SIN_INICIAR}
               showState={true}
             />

--- a/src/components/organisms/logistics/transfer-orders/details/Details.tsx
+++ b/src/components/organisms/logistics/transfer-orders/details/Details.tsx
@@ -436,6 +436,7 @@ export const TransferOrderDetails = () => {
         isOpen={isModalTrackingVisible}
         onClose={() => setIsModalTrackingVisible(false)}
         idTR={transferRequest?.id || 0}
+        refetchNovelty={findNovelties}
       />
     </Flex>
   );

--- a/src/utils/constants/transferOrdersState.ts
+++ b/src/utils/constants/transferOrdersState.ts
@@ -97,3 +97,37 @@ export const TransferOrdersState = [
     bgColor: "#969696"
   }
 ];
+
+export const TransferOrdersTripState = [
+  {
+    id: STATUS.TRIP.SIN_INICIAR,
+    name: "Sin iniciar",
+    bgColor: "#969696"
+  },
+
+  {
+    id: STATUS.TRIP.CARGANDO,
+    name: "Cargando",
+    bgColor: "#0085FF"
+  },
+  {
+    id: STATUS.TRIP.EN_CURSO,
+    name: "En curso",
+    bgColor: "#A9BA43"
+  },
+  {
+    id: STATUS.TRIP.DESCARGANDO,
+    name: "Descargando",
+    bgColor: "#FF6B00"
+  },
+  {
+    id: STATUS.TRIP.DETENIDO,
+    name: "Detenido",
+    bgColor: "#ED171F"
+  },
+  {
+    id: STATUS.TRIP.STAND_BY,
+    name: "Stand by",
+    bgColor: "#3D3D3D"
+  }
+];


### PR DESCRIPTION
This pull request introduces enhancements to the vehicle tracking modals by replacing `TransferOrdersState` with the newly added `TransferOrdersTripState` for better state management and improving the functionality of the `ModalResumeTracking` component. It also includes minor code cleanups and refactoring for improved readability and maintainability.

### State Management Updates:
* Added a new constant `TransferOrdersTripState` in `src/utils/constants/transferOrdersState.ts` to represent trip-specific states, including properties like `id`, `name`, and `bgColor`. This replaces the use of `TransferOrdersState` in components related to trip tracking.
* Updated `ModalHeader` and `ModalResumeTracking` components to use `TransferOrdersTripState` for fetching and displaying trip states. [[1]](diffhunk://#diff-49843643637db864193759ebc3e1827ae82ab7f669b5f685507cc9d5d8d92b50L25-R34) [[2]](diffhunk://#diff-f07e20b9a018fad01252c4dacff639a10988dceb541bed3425d55b6e1d3ee890L119-R129) [[3]](diffhunk://#diff-f07e20b9a018fad01252c4dacff639a10988dceb541bed3425d55b6e1d3ee890L268-R272)

### Component Enhancements:
* Modified the `ModalResumeTracking` component to accept a new `refetchNovelty` prop and invoke it after successfully updating the trip tracking status. This ensures data consistency after state changes. [[1]](diffhunk://#diff-f07e20b9a018fad01252c4dacff639a10988dceb541bed3425d55b6e1d3ee890R37) [[2]](diffhunk://#diff-f07e20b9a018fad01252c4dacff639a10988dceb541bed3425d55b6e1d3ee890L105-R115)
* Updated the `ModalVehicleFollowUp` component to dynamically generate dropdown menu items using `TransferOrdersTripState`, improving maintainability.

### Code Cleanup and Refactoring:
* Removed unused imports and reorganized import statements in `ModalVehicleFollowUp` for better readability.
* Simplified the `GenerateActionButton` click handler in `ModalResumeTracking` by removing unnecessary logging.