### PR TITLE
Remove unnecessary open prop from dropdown in ModalUploadRequirements

### DIFF
--- a/src/components/organisms/logistics/proveedores/ModalUploadRequirements/ModalUploadRequirements.tsx
+++ b/src/components/organisms/logistics/proveedores/ModalUploadRequirements/ModalUploadRequirements.tsx
@@ -337,7 +337,6 @@ const ModalUploadRequirements = ({ isOpen, onClose, documentsTypesList, onUpload
                               }
                             }}
                             popupMatchSelectWidth={false}
-                            open={true}
                             dropdownRender={(menu) => {
                               return <div className="selectRequirementType__dropdown">{menu}</div>;
                             }}


### PR DESCRIPTION
This pull request includes a minor update to the `ModalUploadRequirements` component. The change removes the `open={true}` prop from the `Select` component, likely to allow the dropdown's open state to be controlled dynamically.

* [`src/components/organisms/logistics/proveedores/ModalUploadRequirements/ModalUploadRequirements.tsx`](diffhunk://#diff-7ebc9131326c7904f6af8037d4d0fbbbb3028e5319e0053cd15c9e3cdf804bc3L340): Removed the `open={true}` prop from the `Select` component to enable dynamic control of the dropdown's open state.