### PR TITLE
Feat/add modify trip option in transfer order detail actions

### DIFF
--- a/src/components/molecules/modals/ModalGenerateActionTO/ActionList/ActionList.tsx
+++ b/src/components/molecules/modals/ModalGenerateActionTO/ActionList/ActionList.tsx
@@ -51,10 +51,9 @@ const ActionList = ({
         onClick={() => setSelectedView(ViewEnum.CANCEL_TR)}
       />
       <ButtonGenerateAction
-        disabled={true}
         icon={<ArrowsClockwise size={20} />}
-        title="Modificar solicitud"
-        onClick={() => setSelectedView(ViewEnum.MODIFY_REQUEST)}
+        title="Modificar viaje"
+        onClick={() => setSelectedView(ViewEnum.MODIFY_TRIP)}
       />
       <ButtonGenerateAction
         disabled={!canPreauthorize}

--- a/src/components/molecules/modals/ModalGenerateActionTO/ActionList/ActionList.tsx
+++ b/src/components/molecules/modals/ModalGenerateActionTO/ActionList/ActionList.tsx
@@ -12,7 +12,8 @@ const ActionList = ({
   canFinalizeTrip = true,
   canChangeStatusToPorLegalizar,
   handleChangeStatus,
-  onClose
+  onClose,
+  handleModifyTrip
 }: {
   setSelectedView: Dispatch<SetStateAction<ViewEnum>>;
   canPreauthorize: boolean;
@@ -21,6 +22,7 @@ const ActionList = ({
   // eslint-disable-next-line no-unused-vars
   handleChangeStatus?: (statusId: string) => Promise<void>;
   onClose: () => void;
+  handleModifyTrip: () => void;
 }) => {
   return (
     <Flex style={{ width: "100%", height: "100%" }} gap={12} vertical>
@@ -53,7 +55,7 @@ const ActionList = ({
       <ButtonGenerateAction
         icon={<ArrowsClockwise size={20} />}
         title="Modificar viaje"
-        onClick={() => setSelectedView(ViewEnum.MODIFY_TRIP)}
+        onClick={handleModifyTrip}
       />
       <ButtonGenerateAction
         disabled={!canPreauthorize}

--- a/src/components/molecules/modals/ModalGenerateActionTO/ModalGenerateActionTO.tsx
+++ b/src/components/molecules/modals/ModalGenerateActionTO/ModalGenerateActionTO.tsx
@@ -1,17 +1,21 @@
-import { Flex, Modal } from "antd";
-import { CaretLeft, X } from "phosphor-react";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
-import styles from "./ModalGenerateActionTO.module.scss";
+import { useRouter } from "next/navigation";
+import { Flex, Modal } from "antd";
 import { MessageInstance } from "antd/es/message/interface";
+import { CaretLeft, X } from "phosphor-react";
+
+import FinalizeTrip from "./FinalizeTrip/FinalizeTrip";
 import ActionList from "./ActionList/ActionList";
 import CarrierList from "./CarrierList/CarrierList";
 import PreauthorizeTrip from "./PreauthorizeTrip/PreauthorizeTrip";
-import { BillingByCarrier, BillingStatusEnum } from "@/types/logistics/billing/billing";
-import FinalizeTrip from "./FinalizeTrip/FinalizeTrip";
 import { NavEnum } from "@/components/organisms/logistics/transfer-orders/details/Details";
 import { ModalCancelTR } from "../ModalCancelTR/ModalCancelTR";
-import { ITransferRequestDetail } from "@/types/transferRequest/ITransferRequest";
 import { ModalModifyTrip } from "../ModalModifyTrip/ModalModifyTrip";
+
+import { ITransferRequestDetail } from "@/types/transferRequest/ITransferRequest";
+import { BillingByCarrier, BillingStatusEnum } from "@/types/logistics/billing/billing";
+
+import styles from "./ModalGenerateActionTO.module.scss";
 
 export enum ViewEnum {
   "SELECT_ACTION" = "SELECT_ACTION",
@@ -19,7 +23,6 @@ export enum ViewEnum {
   "FINALIZE_TRIP" = "FINALIZE_TRIP",
   "CHANGE_CARRIER_VEHICLE" = "CHANGE_CARRIER_VEHICLE",
   "CANCEL_TR" = "CANCEL_TR",
-  "MODIFY_TRIP" = "MODIFY_TRIP",
   "PREAUTHORIZE_TRIP" = "PREAUTHORIZE_TRIP"
 }
 type PropsModalGenerateActionTO = {
@@ -56,6 +59,8 @@ export default function ModalGenerateActionTO(props: Readonly<PropsModalGenerate
     (billing) => billing.statusDesc === BillingStatusEnum.Aceptadas
   );
 
+  const router = useRouter();
+
   const renderView = () => {
     switch (selectedView) {
       case ViewEnum.SELECT_ACTION:
@@ -67,6 +72,7 @@ export default function ModalGenerateActionTO(props: Readonly<PropsModalGenerate
             canChangeStatusToPorLegalizar={canChangeStatusToPorLegalizar}
             handleChangeStatus={handleChangeStatus}
             onClose={onClose}
+            handleModifyTrip={() => router.push(`/logistics/transfer-request/${idTR}`)}
           />
         );
       case ViewEnum.SELECT_CARRIER:
@@ -109,8 +115,6 @@ export default function ModalGenerateActionTO(props: Readonly<PropsModalGenerate
             trStatus={transferRequest?.status_id}
           />
         );
-      case ViewEnum.MODIFY_TRIP:
-        return <ModalModifyTrip onCancel={() => setSelectedView(ViewEnum.SELECT_ACTION)} />;
       default:
         return (
           <ActionList
@@ -120,6 +124,7 @@ export default function ModalGenerateActionTO(props: Readonly<PropsModalGenerate
             canChangeStatusToPorLegalizar={false}
             handleChangeStatus={handleChangeStatus}
             onClose={onClose}
+            handleModifyTrip={() => router.push(`/logistics/transfer-request/${idTR}`)}
           />
         );
     }

--- a/src/components/molecules/modals/ModalGenerateActionTO/ModalGenerateActionTO.tsx
+++ b/src/components/molecules/modals/ModalGenerateActionTO/ModalGenerateActionTO.tsx
@@ -11,6 +11,7 @@ import FinalizeTrip from "./FinalizeTrip/FinalizeTrip";
 import { NavEnum } from "@/components/organisms/logistics/transfer-orders/details/Details";
 import { ModalCancelTR } from "../ModalCancelTR/ModalCancelTR";
 import { ITransferRequestDetail } from "@/types/transferRequest/ITransferRequest";
+import { ModalModifyTrip } from "../ModalModifyTrip/ModalModifyTrip";
 
 export enum ViewEnum {
   "SELECT_ACTION" = "SELECT_ACTION",
@@ -18,7 +19,7 @@ export enum ViewEnum {
   "FINALIZE_TRIP" = "FINALIZE_TRIP",
   "CHANGE_CARRIER_VEHICLE" = "CHANGE_CARRIER_VEHICLE",
   "CANCEL_TR" = "CANCEL_TR",
-  "MODIFY_REQUEST" = "MODIFY_REQUEST",
+  "MODIFY_TRIP" = "MODIFY_TRIP",
   "PREAUTHORIZE_TRIP" = "PREAUTHORIZE_TRIP"
 }
 type PropsModalGenerateActionTO = {
@@ -108,6 +109,8 @@ export default function ModalGenerateActionTO(props: Readonly<PropsModalGenerate
             trStatus={transferRequest?.status_id}
           />
         );
+      case ViewEnum.MODIFY_TRIP:
+        return <ModalModifyTrip onCancel={() => setSelectedView(ViewEnum.SELECT_ACTION)} />;
       default:
         return (
           <ActionList

--- a/src/components/molecules/modals/ModalModifyTrip/ModalModifyTrip.tsx
+++ b/src/components/molecules/modals/ModalModifyTrip/ModalModifyTrip.tsx
@@ -1,11 +1,12 @@
-import { useState } from "react";
-import { Flex, Select } from "antd";
+import { useEffect, useState } from "react";
+import { Flex, message, Select } from "antd";
 import { CaretLeft } from "phosphor-react";
 
 import FooterButtons from "@/components/atoms/FooterButtons/FooterButtons";
 
 import "./modalModifyTrip.scss";
 import { Controller, useForm } from "react-hook-form";
+import { getModifyOptions } from "@/services/logistics/transfer-request";
 
 interface Props {
   onCancel: () => void;
@@ -18,8 +19,25 @@ interface IFormValues {
 
 export const ModalModifyTrip = ({ onCancel }: Props) => {
   const [loading, setLoading] = useState(false);
-  // react hook form used below
+  const [options, setOptions] = useState<{ value: number; label: string }[]>([]);
+
   const { handleSubmit, control, register } = useForm<IFormValues>();
+
+  useEffect(() => {
+    const fetchModifyOptions = async () => {
+      try {
+        const response = await getModifyOptions();
+        const formattedOptions = response.map((option) => ({
+          value: option.id,
+          label: option.description
+        }));
+        setOptions(formattedOptions);
+      } catch (error) {
+        message.error("Error al cargar los motivos de modificación");
+      }
+    };
+    fetchModifyOptions();
+  }, []);
 
   const onSubmit = async (data: IFormValues) => {
     console.log("Form data submitted:", data);
@@ -54,10 +72,7 @@ export const ModalModifyTrip = ({ onCancel }: Props) => {
             <Select
               {...field}
               placeholder=" - "
-              options={[
-                { value: "Aprobar", label: "Aprobar" },
-                { value: "Rechazar", label: "Rechazar" }
-              ]}
+              options={options}
               className="modalModifyTrip__select"
             />
           )}

--- a/src/components/molecules/modals/ModalModifyTrip/ModalModifyTrip.tsx
+++ b/src/components/molecules/modals/ModalModifyTrip/ModalModifyTrip.tsx
@@ -1,27 +1,42 @@
+"use client";
 import { useEffect, useState } from "react";
-import { Flex, message, Select } from "antd";
+import { useRouter } from "next/navigation";
+import { Controller, useForm } from "react-hook-form";
+import { Flex, message, Modal, Select } from "antd";
 import { CaretLeft } from "phosphor-react";
 
+import { finishTransferRequest, getModifyOptions } from "@/services/logistics/transfer-request";
 import FooterButtons from "@/components/atoms/FooterButtons/FooterButtons";
 
+import { TransferRequestFinish } from "@/types/logistics/transferRequest/transferRequest";
+
 import "./modalModifyTrip.scss";
-import { Controller, useForm } from "react-hook-form";
-import { getModifyOptions } from "@/services/logistics/transfer-request";
 
 interface Props {
   onCancel: () => void;
+  isOpen?: boolean;
+  TRData?: TransferRequestFinish;
 }
 
 interface IFormValues {
-  motive: string;
-  comment: string;
+  optionId: number;
+  observations: string;
 }
 
-export const ModalModifyTrip = ({ onCancel }: Props) => {
+// All fields optional
+type IFormValuesOptional = {
+  [K in keyof IFormValues]?: IFormValues[K];
+};
+
+export const ModalModifyTrip = ({ onCancel, isOpen, TRData }: Props) => {
+  const router = useRouter();
+
   const [loading, setLoading] = useState(false);
   const [options, setOptions] = useState<{ value: number; label: string }[]>([]);
 
-  const { handleSubmit, control, register } = useForm<IFormValues>();
+  const { handleSubmit, control, reset } = useForm<IFormValues>({
+    defaultValues
+  });
 
   useEffect(() => {
     const fetchModifyOptions = async () => {
@@ -39,63 +54,92 @@ export const ModalModifyTrip = ({ onCancel }: Props) => {
     fetchModifyOptions();
   }, []);
 
+  useEffect(() => {
+    if (!isOpen) {
+      reset(defaultValues);
+    }
+  }, [isOpen]);
+
   const onSubmit = async (data: IFormValues) => {
-    console.log("Form data submitted:", data);
+    setLoading(true);
+
     try {
-      // Handle form submission
+      if (TRData) {
+        await finishTransferRequest(TRData, data);
+        message.success(`TR No. ${TRData.id} asignada`);
+        router.push("/logistics/transfer-orders");
+      } else {
+        message.error("No se encontró la información de la TR.");
+      }
     } catch (error) {
-      // Handle error
+      message.error("Error al finalizar la TR. Por favor, inténtelo de nuevo.");
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
-    <div className="modalModifyTrip">
-      <button onClick={onCancel} className="modalModifyTrip__header">
-        <CaretLeft size="1.25rem" />
-        <span>Modificación de TR</span>
-      </button>
+    <Modal centered width={686} open={isOpen} footer={null} closable={false}>
+      <div className="modalModifyTrip">
+        <button onClick={onCancel} className="modalModifyTrip__header">
+          <CaretLeft size="1.25rem" />
+          <span>Modificación de TR</span>
+        </button>
 
-      <p className="modalModifyTrip__description">
-        Debes informar el motivo del cambio del precio de la TR{" "}
-      </p>
+        <p className="modalModifyTrip__description">
+          Debes informar el motivo del cambio del precio de la TR{" "}
+        </p>
 
-      <div className="modalModifyTrip__content">
-        <Flex vertical>
-          <h4>Motivo del cambio</h4>
-          <p>*Obligatorio</p>
-        </Flex>
-        <Controller
-          control={control}
-          name="motive"
-          rules={{ required: true }}
-          render={({ field }) => (
-            <Select
-              {...field}
-              placeholder=" - "
-              options={options}
-              className="modalModifyTrip__select"
-            />
-          )}
-        />
+        <div className="modalModifyTrip__content">
+          <Flex vertical>
+            <h4>Motivo del cambio</h4>
+            <p>*Obligatorio</p>
+          </Flex>
+          <Controller
+            control={control}
+            name="optionId"
+            rules={{ required: true }}
+            render={({ field }) => (
+              <Select
+                {...field}
+                placeholder=" - "
+                options={options}
+                className="modalModifyTrip__select"
+              />
+            )}
+          />
 
-        <Flex vertical>
-          <h4>Comentarios</h4>
-          <p>*Obligatorio</p>
-        </Flex>
+          <Flex vertical>
+            <h4>Comentarios</h4>
+            <p>*Obligatorio</p>
+          </Flex>
 
-        <textarea
-          className="modalModifyTrip__textarea"
-          placeholder="Ingresar comentario"
-          {...register("comment", { required: "Comentario es obligatorio" })}
+          <Controller
+            control={control}
+            name="observations"
+            rules={{ required: "Comentario es obligatorio" }}
+            render={({ field }) => (
+              <textarea
+                {...field}
+                className="modalModifyTrip__textarea"
+                placeholder="Ingresar comentario"
+              />
+            )}
+          />
+        </div>
+
+        <FooterButtons
+          titleConfirm="Confirmar cambio"
+          handleOk={handleSubmit(onSubmit)}
+          onCancel={onCancel}
+          isConfirmLoading={loading}
         />
       </div>
-
-      <FooterButtons
-        titleConfirm="Confirmar cambio"
-        handleOk={handleSubmit(onSubmit)}
-        onCancel={onCancel}
-        isConfirmLoading={loading}
-      />
-    </div>
+    </Modal>
   );
+};
+
+const defaultValues: IFormValuesOptional = {
+  optionId: undefined,
+  observations: ""
 };

--- a/src/components/molecules/modals/ModalModifyTrip/ModalModifyTrip.tsx
+++ b/src/components/molecules/modals/ModalModifyTrip/ModalModifyTrip.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { Flex, Select } from "antd";
+import { CaretLeft } from "phosphor-react";
+
+import FooterButtons from "@/components/atoms/FooterButtons/FooterButtons";
+
+import "./modalModifyTrip.scss";
+import { Controller, useForm } from "react-hook-form";
+
+interface Props {
+  onCancel: () => void;
+}
+
+interface IFormValues {
+  motive: string;
+  comment: string;
+}
+
+export const ModalModifyTrip = ({ onCancel }: Props) => {
+  const [loading, setLoading] = useState(false);
+  // react hook form used below
+  const { handleSubmit, control, register } = useForm<IFormValues>();
+
+  const onSubmit = async (data: IFormValues) => {
+    console.log("Form data submitted:", data);
+    try {
+      // Handle form submission
+    } catch (error) {
+      // Handle error
+    }
+  };
+
+  return (
+    <div className="modalModifyTrip">
+      <button onClick={onCancel} className="modalModifyTrip__header">
+        <CaretLeft size="1.25rem" />
+        <span>Modificación de TR</span>
+      </button>
+
+      <p className="modalModifyTrip__description">
+        Debes informar el motivo del cambio del precio de la TR{" "}
+      </p>
+
+      <div className="modalModifyTrip__content">
+        <Flex vertical>
+          <h4>Motivo del cambio</h4>
+          <p>*Obligatorio</p>
+        </Flex>
+        <Controller
+          control={control}
+          name="motive"
+          rules={{ required: true }}
+          render={({ field }) => (
+            <Select
+              {...field}
+              placeholder=" - "
+              options={[
+                { value: "Aprobar", label: "Aprobar" },
+                { value: "Rechazar", label: "Rechazar" }
+              ]}
+              className="modalModifyTrip__select"
+            />
+          )}
+        />
+
+        <Flex vertical>
+          <h4>Comentarios</h4>
+          <p>*Obligatorio</p>
+        </Flex>
+
+        <textarea
+          className="modalModifyTrip__textarea"
+          placeholder="Ingresar comentario"
+          {...register("comment", { required: "Comentario es obligatorio" })}
+        />
+      </div>
+
+      <FooterButtons
+        titleConfirm="Confirmar cambio"
+        handleOk={handleSubmit(onSubmit)}
+        onCancel={onCancel}
+        isConfirmLoading={loading}
+      />
+    </div>
+  );
+};

--- a/src/components/molecules/modals/ModalModifyTrip/modalModifyTrip.scss
+++ b/src/components/molecules/modals/ModalModifyTrip/modalModifyTrip.scss
@@ -1,0 +1,68 @@
+@import "@/styles/variables";
+
+.modalModifyTrip {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+
+    &__header {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-family: inherit;
+        font-size: 1.25rem;
+        font-weight: 600;
+        border: none;
+        padding: 0;
+        box-shadow: none;
+        width: fit-content;
+        background-color: transparent;
+        cursor: pointer;
+        // margin to align arrow with content
+        margin-left: -5px;
+
+        &:hover {
+            opacity: 0.6;
+        }
+    }
+
+    &__description {
+        font-size: 1rem;
+        font-weight: 300;
+        width: 100%;
+    }
+
+    &__content {
+        display: grid;
+        grid-template-columns: 2fr 5fr;
+        gap: 1.25rem;
+        // align intems inside row in the center
+        align-items: center;
+
+        p {
+            font-size: 0.75rem;
+            font-weight: 300;
+        }
+
+        h4 {
+            font-size: 0.875rem;
+            font-weight: 400;
+        }
+    }
+
+    &__select {
+        height: 40px !important;
+    }
+
+    &__textarea {
+        background-color: $light-gray;
+        border: none;
+        border-radius: 0.5rem;
+        padding: 0.875rem 1rem;
+        width: 100%;
+        min-height: 4.25rem;
+        resize: none;
+        font-family: inherit;
+        font-size: 0.875rem;
+    }
+}

--- a/src/components/organisms/logistics/orders/transfer_request/PricingTransferRequest.tsx
+++ b/src/components/organisms/logistics/orders/transfer_request/PricingTransferRequest.tsx
@@ -64,6 +64,7 @@ import { TabEnum } from "../../transfer-orders/TransferOrders";
 import ModalCreateJourney from "@/components/molecules/modals/ModalCreateJourney/ModalCreateJourney";
 import { CalendarX } from "phosphor-react";
 import ChipsRow from "../DetailsOrderView/components/ChipsRow";
+import { ModalModifyTrip } from "@/components/molecules/modals/ModalModifyTrip/ModalModifyTrip";
 
 const { Title, Text } = Typography;
 
@@ -119,6 +120,12 @@ export default function PricingTransferRequest({
   const [optionsVehicles, setOptionsVehicles] = useState<any>([]);
   const [modalCarrier, setModalCarrier] = useState(false);
   const [isModalMultiStepOpen, setIsModalMultiStepOpen] = useState(false);
+  const [isModalModifyTripOpen, setIsModalModifyTripOpen] = useState<{
+    open: boolean;
+    data?: TransferRequestFinish;
+  }>({
+    open: false
+  });
 
   const [selectedTrip, setSelectedTrip] = useState<any>(null);
   const [isDeleteAction, setIsDeleteAction] = useState<boolean>(false);
@@ -461,6 +468,14 @@ export default function PricingTransferRequest({
   };
 
   const handleFinish = async (data: TransferRequestFinish) => {
+    if (transferRequest?.general?.was_completed) {
+      // open modal to modify trip
+      return setIsModalModifyTripOpen({
+        open: true,
+        data
+      });
+    }
+
     try {
       await finishTransferRequest(data);
       message.success(`TR No. ${id} asignada`);
@@ -1095,6 +1110,16 @@ export default function PricingTransferRequest({
         isDeleteAction={isDeleteAction}
         handleRevalidate={handleRevalidate}
         data={transferRequest}
+      />
+      <ModalModifyTrip
+        isOpen={isModalModifyTripOpen.open}
+        onCancel={() =>
+          setIsModalModifyTripOpen({
+            open: false,
+            data: undefined
+          })
+        }
+        TRData={isModalModifyTripOpen.data}
       />
     </>
   );

--- a/src/services/logistics/transfer-request.ts
+++ b/src/services/logistics/transfer-request.ts
@@ -383,3 +383,20 @@ export const postponeTR = async (
     throw error as any;
   }
 };
+
+interface IModifyOption {
+  id: number;
+  description: string;
+}
+
+export const getModifyOptions = async (): Promise<IModifyOption[]> => {
+  try {
+    const response: GenericResponse<IModifyOption[]> = await API.get(
+      `/transfer-request/modify-option`
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error get all getModifyOptions: ", error);
+    return error as any;
+  }
+};

--- a/src/services/logistics/transfer-request.ts
+++ b/src/services/logistics/transfer-request.ts
@@ -155,8 +155,18 @@ export const getTransferRequestPricing = async ({
   );
 };
 
-export const finishTransferRequest = async (data: TransferRequestFinish) => {
-  const response: GenericResponse<boolean> = await API.post(`/transfer-request/finish`, data);
+export const finishTransferRequest = async (
+  data: TransferRequestFinish,
+  change?: {
+    optionId: number;
+    observations: string;
+  }
+) => {
+  const body = {
+    ...data,
+    ...(change && { change })
+  };
+  const response: GenericResponse<boolean> = await API.post(`/transfer-request/finish`, body);
   if (response.success) return response.data;
   throw new Error(
     response?.message || "Error obteniendo los pasos de la solicitud de transferencia"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/44cb5bb0-72d9-4001-bf5e-c4c6e98cd9bf)
This pull request introduces functionality to modify transfer requests (TRs) and integrates it into various components of the logistics module. The most significant changes include adding a new modal for modifying trips, updating existing components to support trip modification, and extending the backend services to handle modification options and requests.

### Frontend changes for trip modification:

* **New modal component for trip modification:**
  - Created `ModalModifyTrip` component with form fields for selecting modification reasons and adding comments. Includes validation, state management, and API integration for submitting modifications. (`src/components/molecules/modals/ModalModifyTrip/ModalModifyTrip.tsx`, [src/components/molecules/modals/ModalModifyTrip/ModalModifyTrip.tsxR1-R145](diffhunk://#diff-2d8851e5ab3492c931531411740f1579993b0810dfe44c29b51d2d23b05c4f2fR1-R145))
  - Added corresponding styles in `modalModifyTrip.scss`. (`src/components/molecules/modals/ModalModifyTrip/modalModifyTrip.scss`, [src/components/molecules/modals/ModalModifyTrip/modalModifyTrip.scssR1-R68](diffhunk://#diff-b45e4efad0ea383d7536c3b8a6593d8e21b8deced540ce08facdeb43903eff02R1-R68))

* **Integration of trip modification modal:**
  - Integrated `ModalModifyTrip` into `PricingTransferRequest` to handle cases where completed transfer requests require modification. (`src/components/organisms/logistics/orders/transfer_request/PricingTransferRequest.tsx`, [[1]](diffhunk://#diff-f16285df80035a0815906d969ef2937a28d6da04966b0723ed851e054df3969eR67) [[2]](diffhunk://#diff-f16285df80035a0815906d969ef2937a28d6da04966b0723ed851e054df3969eR123-R128) [[3]](diffhunk://#diff-f16285df80035a0815906d969ef2937a28d6da04966b0723ed851e054df3969eR471-R478) [[4]](diffhunk://#diff-f16285df80035a0815906d969ef2937a28d6da04966b0723ed851e054df3969eR1114-R1123)

* **Updates to `ModalGenerateActionTO`:**
  - Modified action list to include a "Modificar viaje" button, which triggers navigation to the transfer request modification page. (`src/components/molecules/modals/ModalGenerateActionTO/ActionList/ActionList.tsx`, [[1]](diffhunk://#diff-12b70c6db379badd187e024ce5b00f52700ae7b97b48158da3a07bb2411bad29L15-R16) [[2]](diffhunk://#diff-12b70c6db379badd187e024ce5b00f52700ae7b97b48158da3a07bb2411bad29R25) [[3]](diffhunk://#diff-12b70c6db379badd187e024ce5b00f52700ae7b97b48158da3a07bb2411bad29L60-R64)
  - Updated logic to support redirection for trip modification. (`src/components/molecules/modals/ModalGenerateActionTO/ModalGenerateActionTO.tsx`, [[1]](diffhunk://#diff-414830bdf1f3652e229f03d176e4321477c5d9a6039d092b2fd9b5773d9095e0L1-L22) [[2]](diffhunk://#diff-414830bdf1f3652e229f03d176e4321477c5d9a6039d092b2fd9b5773d9095e0R65-R66) [[3]](diffhunk://#diff-414830bdf1f3652e229f03d176e4321477c5d9a6039d092b2fd9b5773d9095e0R78) [[4]](diffhunk://#diff-414830bdf1f3652e229f03d176e4321477c5d9a6039d092b2fd9b5773d9095e0R143)

### Backend service updates:

* **Support for trip modification options:**
  - Added a new `getModifyOptions` API service to fetch available modification reasons. (`src/services/logistics/transfer-request.ts`, [src/services/logistics/transfer-request.tsR409-R425](diffhunk://#diff-44ff68af56cef3ecdefe1be7e49a5335206f34258af608ed5775b05e2b2dca9aR409-R425))

* **Extended `finishTransferRequest` API:**
  - Updated `finishTransferRequest` to accept optional modification details (reason and observations) when finalizing a transfer request. (`src/services/logistics/transfer-request.ts`, [src/services/logistics/transfer-request.tsL158-R169](diffhunk://#diff-44ff68af56cef3ecdefe1be7e49a5335206f34258af608ed5775b05e2b2dca9aL158-R169))