### PR TITLE
Fix/fixed scroll in transfer orders

### DIFF
--- a/src/components/atoms/Container/Container.module.scss
+++ b/src/components/atoms/Container/Container.module.scss
@@ -2,9 +2,7 @@
 
 .container {
     width: 100%;
-    height: 100vh;
-    padding: 2rem;
+    padding: 1rem 2rem;
     background-color: $white;
     border-radius: 0.5rem;
-    overflow-y: auto;
 }

--- a/src/components/molecules/tables/TransferOrderTable/TransferOrderTable.tsx
+++ b/src/components/molecules/tables/TransferOrderTable/TransferOrderTable.tsx
@@ -130,6 +130,12 @@ export const TransferOrdersTable: FC<ITransferOrdersTable> = ({
         showSizeChanger: false
       }}
       loading={loading}
+      className="customSticky"
+      sticky={
+        {
+          offsetHeader: 130
+        } as any
+      }
     />
   );
 };

--- a/src/components/organisms/logistics/transfer-orders/TransferOrders.tsx
+++ b/src/components/organisms/logistics/transfer-orders/TransferOrders.tsx
@@ -184,7 +184,11 @@ export const TransferOrders = () => {
   return (
     <SearchProvider debounceDelay={500}>
       <Container>
-        <Flex justify="space-between" style={{ marginBottom: "1rem" }}>
+        <Flex
+          justify="space-between"
+          className={styles.stickyHeader}
+          style={{ marginBottom: "1rem" }}
+        >
           <div className={styles.filterContainer}>
             <UiSearchInput className="search" placeholder="Buscar" />
             <Filter />

--- a/src/components/organisms/logistics/transfer-orders/completed/completed.tsx
+++ b/src/components/organisms/logistics/transfer-orders/completed/completed.tsx
@@ -126,5 +126,5 @@ export const Completed: FC<ICompletedProps> = ({ allSelectedRows, handleCheckAll
       </div>
     );
 
-  return <CustomCollapse ghost items={renderItems} defaultActiveKey={["0"]} />;
+  return <CustomCollapse ghost items={renderItems} defaultActiveKey={["0"]} stickyLabel />;
 };

--- a/src/components/organisms/logistics/transfer-orders/in-process/InProcess.tsx
+++ b/src/components/organisms/logistics/transfer-orders/in-process/InProcess.tsx
@@ -155,5 +155,5 @@ export const InProcess: FC<IInProcessProps> = ({
       </div>
     );
 
-  return <CustomCollapse ghost items={renderItems} defaultActiveKey={["0"]} />;
+  return <CustomCollapse ghost items={renderItems} defaultActiveKey={["0"]} stickyLabel />;
 };

--- a/src/components/organisms/logistics/transfer-orders/request/Request.tsx
+++ b/src/components/organisms/logistics/transfer-orders/request/Request.tsx
@@ -204,5 +204,5 @@ export const Request: FC<IRequestProps> = ({
       </div>
     );
 
-  return <CustomCollapse ghost items={renderItems} defaultActiveKey={["0"]} />;
+  return <CustomCollapse ghost items={renderItems} defaultActiveKey={["0"]} stickyLabel />;
 };

--- a/src/components/organisms/logistics/transfer-orders/transferOrders.module.scss
+++ b/src/components/organisms/logistics/transfer-orders/transferOrders.module.scss
@@ -1,26 +1,42 @@
+@import "@/styles/variables.scss";
 
 .filterContainer {
-  display: flex;
-  column-gap: 0.5rem;
+    display: flex;
+    column-gap: 0.5rem;
 }
 
 .tabContainer {
-  display: flex;
-  column-gap: 2rem;
-  border-bottom: 1px solid #DDD;
+    display: flex;
+    column-gap: 2rem;
+    border-bottom: 1px solid #ddd;
+    position: -webkit-sticky;
+    position: sticky;
+    top: 4rem;
+    z-index: 11;
+    background-color: $white;
 }
 
 .tab {
-  padding-bottom: 4px;
-  color: #DDD;
-  font-size: 16px;
-  font-weight: 600;
-  cursor: pointer;
+    padding-bottom: 4px;
+    color: #ddd;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
 
-  &.active {
-    color: #141414;
-    font-weight: 700;
-    border-bottom: 1px solid #141414;
-  }
+    &.active {
+        color: #141414;
+        font-weight: 700;
+        border-bottom: 1px solid #141414;
+    }
 }
 
+.stickyHeader {
+    position: -webkit-sticky;
+    position: sticky;
+    top: -1rem;
+    background-color: $white;
+    z-index: 11;
+    padding: 1rem 0;
+    margin-left: -0.5rem;
+    margin-bottom: 0;
+}

--- a/src/components/ui/custom-collapse/CustomCollapse.tsx
+++ b/src/components/ui/custom-collapse/CustomCollapse.tsx
@@ -1,11 +1,19 @@
 import { Collapse, CollapseProps, ConfigProvider, Empty } from "antd";
+import "./customCollapse.scss";
+
+interface CustomCollapseProps extends CollapseProps {
+  stickyLabel?: boolean;
+  labelStickyOffset?: string;
+}
 
 export default function CustomCollapse({
   items,
   ghost,
   defaultActiveKey,
+  stickyLabel,
+  labelStickyOffset,
   ...rest
-}: Readonly<CollapseProps>) {
+}: Readonly<CustomCollapseProps>) {
   const hasValidItems = items && items.length > 0;
   return (
     <ConfigProvider
@@ -18,7 +26,18 @@ export default function CustomCollapse({
       }}
     >
       {hasValidItems ? (
-        <Collapse ghost items={items} defaultActiveKey={defaultActiveKey ?? ["0"]} {...rest} />
+        <Collapse
+          style={
+            {
+              "--sticky-offset": `${labelStickyOffset ? labelStickyOffset : "5.6rem"}`
+            } as React.CSSProperties
+          }
+          className={`genericCollapse ${stickyLabel ? "sticky" : ""}`}
+          ghost
+          items={items}
+          defaultActiveKey={defaultActiveKey ?? ["0"]}
+          {...rest}
+        />
       ) : (
         <Empty description="No hay información disponible" />
       )}

--- a/src/components/ui/custom-collapse/customCollapse.scss
+++ b/src/components/ui/custom-collapse/customCollapse.scss
@@ -1,0 +1,16 @@
+@import "@/styles/variables.scss";
+
+.genericCollapse {
+    &.sticky {
+        .ant-collapse-item {
+            position: relative; // Create positioning context
+        }
+
+        .ant-collapse-header {
+            position: sticky !important;
+            top: var(--sticky-offset) !important;
+            z-index: 2 !important;
+            background-color: $white;
+        }
+    }
+}

--- a/src/components/ui/custom-collapse/customCollapse.scss
+++ b/src/components/ui/custom-collapse/customCollapse.scss
@@ -1,6 +1,17 @@
 @import "@/styles/variables.scss";
 
 .genericCollapse {
+    .ant-collapse-item {
+        // to prevent the content to appear distorted when the collapse is opening or closing
+        .ant-motion-collapse,
+        .ant-motion-collapse-enter,
+        .ant-motion-collapse-enter-active,
+        .ant-motion-collapse-leave,
+        .ant-motion-collapse-leave-active {
+            display: none !important;
+        }
+    }
+
     &.sticky {
         .ant-collapse-item {
             position: relative; // Create positioning context

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -172,3 +172,15 @@ a {
     -webkit-text-fill-color: transparent;
     font-weight: 500;
 }
+
+.customSticky {
+    .ant-table-sticky-holder {
+        // this leaves a blank space when the header is sticky
+        // so the scrollable content is not seen behind the header
+        // between the header and the label or top content
+        padding-top: 0.5rem;
+        margin-top: -0.5rem;
+        background-color: $white !important;
+        z-index: 1 !important;
+    }
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1726391a-11ad-4ee0-9193-a400c3410b2c)
This pull request introduces several changes to improve the user interface by adding sticky elements for better usability, modifying styles for consistency, and enhancing the `CustomCollapse` component to support sticky headers. Below is a breakdown of the most important changes:

### Sticky Elements and Usability Enhancements:
* Added a `stickyHeader` class to the `TransferOrders` component to make the header sticky with appropriate styles (`transferOrders.module.scss`).
* Updated the `TransferOrdersTable` component to include a `customSticky` class and a sticky table header with an offset (`TransferOrderTable.tsx`).
* Enhanced the `CustomCollapse` component to support sticky labels with a new `stickyLabel` prop and CSS adjustments (`CustomCollapse.tsx`, `customCollapse.scss`). [[1]](diffhunk://#diff-763ea1e97f3ce28725175e02070c5c882427c513fef5d9c781a1d7a3abef527eR2-R16) [[2]](diffhunk://#diff-763ea1e97f3ce28725175e02070c5c882427c513fef5d9c781a1d7a3abef527eL21-R40) [[3]](diffhunk://#diff-c38570d7faba231cfc2a5c3fd64c80dce1e2f1fc1ba4baba22d8e0e94eb534ddR1-R27)

### Style Improvements:
* Adjusted the `container` styles by modifying padding and removing unnecessary properties (`Container.module.scss`).
* Made the `tabContainer` sticky with consistent styling and improved positioning (`transferOrders.module.scss`).

### Codebase Enhancements:
* Extended the `CustomCollapse` component's props to include `stickyLabel` and `labelStickyOffset`, allowing for flexible sticky header functionality (`CustomCollapse.tsx`). [[1]](diffhunk://#diff-763ea1e97f3ce28725175e02070c5c882427c513fef5d9c781a1d7a3abef527eR2-R16) [[2]](diffhunk://#diff-763ea1e97f3ce28725175e02070c5c882427c513fef5d9c781a1d7a3abef527eL21-R40)
* Applied the `stickyLabel` feature to multiple components (`Completed.tsx`, `InProcess.tsx`, `Request.tsx`). [[1]](diffhunk://#diff-2326036c891079d567ad3603b3141b802275ba7697cc8d80d95545c961cb53ddL129-R129) [[2]](diffhunk://#diff-69a73d4c1abcfeaa5032e825dbdcf8f184cf84555e76ffa0420f1208b2785f43L158-R158) [[3]](diffhunk://#diff-fa4f747d5100580f2f5211ac6ebc67553a68049852dba843109dfea127969740L207-R207)