### PR TITLE
Add accept invitation flow to auth module

### DIFF
--- a/src/app/auth/accept-invitation/layout.ts
+++ b/src/app/auth/accept-invitation/layout.ts
@@ -1,0 +1,10 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Aceptar invitación",
+  description: "Aceptar invitación"
+};
+
+export default function AcceptInvitationLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/auth/accept-invitation/page.tsx
+++ b/src/app/auth/accept-invitation/page.tsx
@@ -1,0 +1,5 @@
+import { ChangePass } from "@/components/organisms/auth/changePass/ChangePass";
+
+export default function AcceptInvitationPage() {
+  return <ChangePass mode="accept" />;
+}

--- a/src/app/auth/changePass/page.tsx
+++ b/src/app/auth/changePass/page.tsx
@@ -3,6 +3,6 @@
 import { ChangePass } from "@/components/organisms/auth/changePass/ChangePass";
 
 function ChangePassPage() {
-  return <ChangePass />;
+  return <ChangePass mode="change" />;
 }
 export default ChangePassPage;

--- a/src/components/molecules/login/ChangePassForm/ChangePassForm.tsx
+++ b/src/components/molecules/login/ChangePassForm/ChangePassForm.tsx
@@ -25,7 +25,7 @@ const schema = yup.object().shape({
     .required()
 });
 
-export const ChangePassForm = () => {
+export const ChangePassForm = ({ mode }: { mode: "accept" | "change" }) => {
   const [isLoading, setIsLoading] = useState(false);
   const searchParams = useSearchParams();
   const oobCode = searchParams.get("oobCode");
@@ -57,8 +57,11 @@ export const ChangePassForm = () => {
       openNotification({
         api: api,
         type: "success",
-        title: "Contraseña restablecida",
-        message: "Tu contraseña ha sido restablecida"
+        title: mode === "change" ? "Contraseña restablecida" : "Invitación aceptada",
+        message:
+          mode === "change"
+            ? "Tu contraseña ha sido restablecida"
+            : "Tu invitación ha sido aceptada"
       });
       setTimeout(() => {
         router.push("/auth/login");
@@ -73,13 +76,24 @@ export const ChangePassForm = () => {
     }
     setIsLoading(false);
   };
+
+  const texts =
+    mode !== "accept"
+      ? {
+          title: "Restablece tu contraseña",
+          description: "Ingresa tu nueva contraseña"
+        }
+      : {
+          title: "Aceptar invitación",
+          description: "Crea una nueva contraseña"
+        };
   if (!oobCode) return;
   return (
     <form className="changePassForm" onSubmit={handleSubmit(onSubmitHandler)}>
       {contextHolder}
       <Flex vertical gap={"0.5rem"}>
-        <h4 className="changePassForm__title">Restablece tu contraseña</h4>
-        <p>Ingresa tu nueva contraseña</p>
+        <h4 className="changePassForm__title">{texts.title}</h4>
+        <p>{texts.description}</p>
       </Flex>
 
       <Flex vertical gap={"1.5rem"} className="changePassForm__content">

--- a/src/components/organisms/auth/changePass/ChangePass.tsx
+++ b/src/components/organisms/auth/changePass/ChangePass.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Flex } from "antd";
 
 import { InfoCardLogin } from "@/components/molecules/login/InfoCardLogin/InfoCardLogin";
@@ -9,7 +10,7 @@ import { LogoCashport } from "@/components/atoms/logoCashport/LogoCashport";
 import { Suspense } from "react";
 import Loader from "@/components/atoms/loaders/loader";
 
-export const ChangePass = () => {
+export const ChangePass = ({ mode }: { mode: 'accept' | 'change' }) => {
   return (
     <main className={styles.containerChangePass}>
       <InfoCardLogin />
@@ -19,7 +20,7 @@ export const ChangePass = () => {
             <LogoCashport width={370} height={100} />
           </div>
           <Suspense fallback={<Loader />}>
-            <ChangePassForm />
+            <ChangePassForm mode={mode} />
           </Suspense>
           <ContactUsButton />
         </Flex>


### PR DESCRIPTION
Introduced new pages and layout for accepting invitations under /auth/accept-invitation. Refactored ChangePass and ChangePassForm components to support both password change and invitation acceptance modes, updating UI texts and notification messages accordingly. Updated routing to pass the appropriate mode prop.