### PR TITLE
Fix initial view state in CreateOrderVieww to default to 'scheduling'

### DIFF
--- a/src/components/organisms/logistics/orders/CreateOrderVieww/CreateOrderVieww.tsx
+++ b/src/components/organisms/logistics/orders/CreateOrderVieww/CreateOrderVieww.tsx
@@ -109,7 +109,7 @@ export interface IFormCreateOrder {
 export type IViewOption = "scheduling" | "load" | "additionalInfo";
 
 export const CreateOrderVieww: React.FC = () => {
-  const [view, setView] = useState<IViewOption>("additionalInfo");
+  const [view, setView] = useState<IViewOption>("scheduling");
   const [loadingRequest, setLoadingRequest] = useState<boolean>(false);
 
   const { push } = useRouter();


### PR DESCRIPTION
This pull request includes a minor change to the default state of the `view` variable in the `CreateOrderVieww` component. The default view has been updated from `"additionalInfo"` to `"scheduling"`.

* [`src/components/organisms/logistics/orders/CreateOrderVieww/CreateOrderVieww.tsx`](diffhunk://#diff-390c88ac1f2adacb94c46c9393e3cf3accb87430a396b32fbddc859685780ff5L112-R112): Changed the initial state of the `view` variable in the `useState` hook to `"scheduling"` instead of `"additionalInfo"`.