### PR TITLE
Update SWR keys for trip types fetching

### DIFF
--- a/src/components/organisms/logistics/driver/createDriver/createDriver.tsx
+++ b/src/components/organisms/logistics/driver/createDriver/createDriver.tsx
@@ -57,7 +57,7 @@ export const CreateDriverView = ({ params }: Props) => {
     getVehicleType,
     { revalidateIfStale: false, revalidateOnFocus: false, revalidateOnReconnect: false }
   );
-  const { data: tripTypes, isLoading: isloadingTripTypes } = useSWR("1", getTripTypes, {
+  const { data: tripTypes, isLoading: isloadingTripTypes } = useSWR("getTripTypesDriver", getTripTypes, {
     revalidateIfStale: false,
     revalidateOnFocus: false,
     revalidateOnReconnect: false

--- a/src/components/organisms/logistics/driver/driverInfo/driverInfo.tsx
+++ b/src/components/organisms/logistics/driver/driverInfo/driverInfo.tsx
@@ -103,7 +103,7 @@ export const DriverInfoView = ({ params }: Props) => {
     getVehicleType,
     { revalidateIfStale: false, revalidateOnFocus: false, revalidateOnReconnect: false }
   );
-  const { data: tripTypes, isLoading: isloadingTripTypes } = useSWR("1", getTripTypes, {
+  const { data: tripTypes, isLoading: isloadingTripTypes } = useSWR("getTripTypesDriver", getTripTypes, {
     revalidateIfStale: false,
     revalidateOnFocus: false,
     revalidateOnReconnect: false

--- a/src/components/organisms/logistics/proveedores/providerInfo/providerInfo.tsx
+++ b/src/components/organisms/logistics/proveedores/providerInfo/providerInfo.tsx
@@ -61,7 +61,7 @@ export const ProviderInfoView = ({ isEdit = false, idParam, statusFormProp = "re
     }
   };
 
-  const { data: tripTypes, isLoading: isloadingTripTypes } = useSWR("1", getTripTypes, {
+  const { data: tripTypes, isLoading: isloadingTripTypes } = useSWR("getTripTypesProvider", getTripTypes, {
     revalidateIfStale: false,
     revalidateOnFocus: false,
     revalidateOnReconnect: false


### PR DESCRIPTION
Changed the SWR cache keys from '1' to more descriptive values ('getTripTypesDriver' and 'getTripTypesProvider') in driver and provider components to improve cache management and clarity.