### PR TITLE
Add mutateData prop to DriverFormTab and VehicleFormTab for data refreshing after audits

### DIFF
--- a/src/components/molecules/tabs/logisticsForms/driverForm/driverFormTab.mapper.tsx
+++ b/src/components/molecules/tabs/logisticsForms/driverForm/driverFormTab.mapper.tsx
@@ -41,6 +41,7 @@ export interface DriverFormTabProps {
   vehiclesTypesList: VehicleType[];
   isLoadingSubmit: boolean;
   tripTypes: ITripType[];
+  mutateData?: () => void;
 }
 
 export type DriverData = IAPIDriver & { licence?: string } & { documents?: ICertificates[] };

--- a/src/components/molecules/tabs/logisticsForms/driverForm/driverFormTab.tsx
+++ b/src/components/molecules/tabs/logisticsForms/driverForm/driverFormTab.tsx
@@ -71,7 +71,8 @@ export const DriverFormTab = ({
   vehiclesTypesList,
   isLoadingSubmit,
   tripTypes,
-  onAuditDriver = async () => {}
+  onAuditDriver = async () => {},
+  mutateData = () => {}
 }: DriverFormTabProps) => {
   const [isModalOpen, setIsModalOpen] = useState({
     selected: 0
@@ -195,6 +196,7 @@ export const DriverFormTab = ({
     try {
       await auditWithCashportAI(subjectId);
       message.success("Auditoría enviada con éxito a CashportAI.");
+      mutateData();
     } catch (error) {
       message.error("Error al enviar auditoría.");
       console.error("Audit error:", error);

--- a/src/components/molecules/tabs/logisticsForms/vehicleForm/vehicleFormTab.mapper.tsx
+++ b/src/components/molecules/tabs/logisticsForms/vehicleForm/vehicleFormTab.mapper.tsx
@@ -36,6 +36,7 @@ export interface VehicleFormTabProps {
   vehiclesTypesList: VehicleType[];
   features: IFeature[];
   isLoading: boolean;
+  mutateData?: () => void;
 }
 export interface VehicleImage {
   id: number;

--- a/src/components/molecules/tabs/logisticsForms/vehicleForm/vehicleFormTab.tsx
+++ b/src/components/molecules/tabs/logisticsForms/vehicleForm/vehicleFormTab.tsx
@@ -68,7 +68,8 @@ export const VehicleFormTab = ({
   features = [],
   isLoading,
   // eslint-disable-next-line no-unused-vars
-  onAuditVehicle = () => {}
+  onAuditVehicle = () => {},
+  mutateData = () => {}
 }: VehicleFormTabProps) => {
   const [isModalOpen, setIsModalOpen] = useState({
     selected: 0
@@ -161,6 +162,8 @@ export const VehicleFormTab = ({
     try {
       await auditWithCashportAI(subjectId);
       message.success("Auditoría enviada con éxito a CashportAI.");
+      // TO DO: Mutate to refresh the data after audit
+      mutateData();
     } catch (error) {
       message.error("Error al enviar auditoría.");
       console.error("Audit error:", error);

--- a/src/components/organisms/logistics/driver/driverInfo/driverInfo.tsx
+++ b/src/components/organisms/logistics/driver/driverInfo/driverInfo.tsx
@@ -43,7 +43,7 @@ export const DriverInfoView = ({ params }: Props) => {
     return getDriverById(params.driverId);
   };
 
-  const { data, isLoading, isValidating } = useSWR(params.driverId, fetcher, {
+  const { data, isLoading, isValidating, mutate } = useSWR(params.driverId, fetcher, {
     revalidateIfStale: false,
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
@@ -128,6 +128,7 @@ export const DriverInfoView = ({ params }: Props) => {
         vehiclesTypesList={vehiclesTypesData ?? []}
         isLoadingSubmit={isLoadingSubmit}
         tripTypes={tripTypes ?? []}
+        mutateData={mutate}
       />
     </Skeleton>
   );

--- a/src/components/organisms/logistics/vehicles/vehiclesInfo/VehicleInfo.tsx
+++ b/src/components/organisms/logistics/vehicles/vehiclesInfo/VehicleInfo.tsx
@@ -114,6 +114,7 @@ export const VehicleInfoView = ({ idParam = "", params }: Props) => {
         onDesactivateVehicle={() => handlechangeStatus(0)}
         onAuditVehicle={() => handlechangeStatus(2)}
         features={features || []}
+        mutateData={mutate}
       />
     </Skeleton>
   );


### PR DESCRIPTION

This pull request introduces a new `mutateData` function to refresh data after specific actions in both the Driver and Vehicle forms. It ensures that the data displayed is up-to-date following audits or other operations. The changes span across multiple files and components, integrating the `mutateData` function into the props and logic of these components.

### Integration of `mutateData` for refreshing data:

#### Driver-related changes:
* [`src/components/molecules/tabs/logisticsForms/driverForm/driverFormTab.mapper.tsx`](diffhunk://#diff-9d2db92b5d931399a8ce08956d16e2c6f5eb4417744cf208e64cfa3e24b114faR44): Added an optional `mutateData` property to the `DriverFormTabProps` interface.
* [`src/components/molecules/tabs/logisticsForms/driverForm/driverFormTab.tsx`](diffhunk://#diff-c8dc27fd004649c70724d984c3852adc71feaf55be3238ea1d355758ec6d4006L74-R75): Integrated `mutateData` into the `DriverFormTab` component props and invoked it after successful audit submission. [[1]](diffhunk://#diff-c8dc27fd004649c70724d984c3852adc71feaf55be3238ea1d355758ec6d4006L74-R75) [[2]](diffhunk://#diff-c8dc27fd004649c70724d984c3852adc71feaf55be3238ea1d355758ec6d4006R199)
* [`src/components/organisms/logistics/driver/driverInfo/driverInfo.tsx`](diffhunk://#diff-bf73c26b1def532c4cfcd39cdb2966caa44d819e4af6bcbdaecd315f0fa68307L46-R46): Passed the `mutate` function from `useSWR` as `mutateData` to the `DriverFormTab` component, enabling data refresh. [[1]](diffhunk://#diff-bf73c26b1def532c4cfcd39cdb2966caa44d819e4af6bcbdaecd315f0fa68307L46-R46) [[2]](diffhunk://#diff-bf73c26b1def532c4cfcd39cdb2966caa44d819e4af6bcbdaecd315f0fa68307R131)

#### Vehicle-related changes:
* [`src/components/molecules/tabs/logisticsForms/vehicleForm/vehicleFormTab.mapper.tsx`](diffhunk://#diff-30bd14bcef65e404836fbc4623070dce6caf66c6b31a22a8828d41ba25c62e07R39): Added an optional `mutateData` property to the `VehicleFormTabProps` interface.
* [`src/components/molecules/tabs/logisticsForms/vehicleForm/vehicleFormTab.tsx`](diffhunk://#diff-65c45ff412746222da33299f19ce5cd89a59bc3cea8da1eeddb3bd2d8d9d6012L71-R72): Integrated `mutateData` into the `VehicleFormTab` component props and invoked it after successful audit submission. [[1]](diffhunk://#diff-65c45ff412746222da33299f19ce5cd89a59bc3cea8da1eeddb3bd2d8d9d6012L71-R72) [[2]](diffhunk://#diff-65c45ff412746222da33299f19ce5cd89a59bc3cea8da1eeddb3bd2d8d9d6012R165-R166)
* [`src/components/organisms/logistics/vehicles/vehiclesInfo/VehicleInfo.tsx`](diffhunk://#diff-2594e8b537ee4ac429e0bbda3930a365ec0abb8ef4f31ac611b922484e6e776dR117): Passed the `mutate` function from `useSWR` as `mutateData` to the `VehicleFormTab` component, enabling data refresh.