### PR TITLE
Add light-gray-cartera variable and update timeAgoText color

### DIFF
--- a/src/components/organisms/logistics/proveedores/DrawerComponent/sections/eventsection.scss
+++ b/src/components/organisms/logistics/proveedores/DrawerComponent/sections/eventsection.scss
@@ -86,7 +86,7 @@
             .timeAgoText {
                 font-size: 0.75rem;
                 font-weight: 400;
-                color: $light-gray;
+                color: $light-gray-cartera;
             }
 
             .username {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -11,6 +11,7 @@ $dark-gray: #dddddd;
 $secondary-gray: #575a6b;
 $darker-gray: #787878;
 $light-gray: #fafafa;
+$light-gray-cartera: #a5a5a5;
 $real-dark-gray: #3f3f3f;
 
 $pending: #ffb800;


### PR DESCRIPTION
This pull request introduces a small change to the styling of the `eventsection.scss` file by updating a color variable and adding a new color variable to the `_variables.scss` file for consistency.

### Styling updates:

* [`src/styles/_variables.scss`](diffhunk://#diff-39d5aa9e27fa49139a93a25f23ca7e34422ec0751ee97b761ee6322f69a7ec85R14): Added a new color variable `$light-gray-cartera` with the value `#a5a5a5`.
* [`src/components/organisms/logistics/proveedores/DrawerComponent/sections/eventsection.scss`](diffhunk://#diff-5763ee63e4903324254d5cc87ada4b2eca14ce681f45588deca3efff7fb86b01L89-R89): Updated the `.timeAgoText` class to use the new `$light-gray-cartera` color instead of `$light-gray`.