### PR TITLE
Feat/add warning in transfer order table

### DIFF
--- a/src/components/molecules/tables/TransferOrderTable/columns/TOColumns.tsx
+++ b/src/components/molecules/tables/TransferOrderTable/columns/TOColumns.tsx
@@ -5,7 +5,7 @@ import { Eye, Warning, WarningOctagon } from "phosphor-react";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { formatMoney, formatTimeAgo } from "@/utils/utils";
-import { Radioactive } from "@phosphor-icons/react";
+import { Radioactive, WarningCircle } from "@phosphor-icons/react";
 import "./transferOrderTable.scss";
 import Link from "next/link";
 
@@ -195,36 +195,57 @@ export const columns = (
     {
       title: "",
       dataIndex: "validator",
-      render: (text: {
-        tr: string;
-        ismaterialsproblem: boolean;
-        ispeopleproblem: boolean;
-        isRejected: boolean;
-      }) => (
-        <div className="btnContainer">
-          {text.isRejected && (
-            <Button
-              className="btn"
-              type="text"
-              size="middle"
-              icon={
-                <Tooltip title="Esta orden tiene una factura rechazada">
-                  <WarningOctagon size={24} color="red" />
-                </Tooltip>
-              }
-            />
-          )}
-          {!!text.ismaterialsproblem && (
-            <Button className="btn" type="text" size="middle" icon={<Radioactive size={24} />} />
-          )}
-          {!!text.ismaterialsproblem && (
-            <Button className="btn" type="text" size="middle" icon={<Warning size={24} />} />
-          )}
-          <Link href={`${redirect ? redirect : "/logistics/transfer-orders/details"}/${text.tr}`}>
-            <Button className="btn" type="text" size="middle" icon={<Eye size={24} />} />
-          </Link>
-        </div>
-      )
+      render: (
+        text: {
+          tr: string;
+          ismaterialsproblem: boolean;
+          ispeopleproblem: boolean;
+          isRejected: boolean;
+        },
+        row
+      ) => {
+        const hoursUntilTrip = dayjs(row.fechas.origin).diff(dayjs(), "hour");
+        const is24HoursOrLessToTrip =
+          (hoursUntilTrip >= 0 && hoursUntilTrip <= 24) || hoursUntilTrip < 0;
+
+        return (
+          <div className="btnContainer">
+            {text.isRejected && (
+              <Button
+                className="btn"
+                type="text"
+                size="middle"
+                icon={
+                  <Tooltip title="Esta orden tiene una factura rechazada">
+                    <WarningOctagon size={24} color="red" />
+                  </Tooltip>
+                }
+              />
+            )}
+            {!!text.ismaterialsproblem && (
+              <Button className="btn" type="text" size="middle" icon={<Radioactive size={24} />} />
+            )}
+            {!!text.ismaterialsproblem && (
+              <Button className="btn" type="text" size="middle" icon={<Warning size={24} />} />
+            )}
+
+            {is24HoursOrLessToTrip && (
+              <Tooltip title="Este viaje inicia en menos de 24 horas">
+                <Button
+                  className="btn"
+                  type="text"
+                  size="middle"
+                  icon={<WarningCircle size={24} color="#FF4D4F" />}
+                />
+              </Tooltip>
+            )}
+
+            <Link href={`${redirect ? redirect : "/logistics/transfer-orders/details"}/${text.tr}`}>
+              <Button className="btn" type="text" size="middle" icon={<Eye size={24} />} />
+            </Link>
+          </div>
+        );
+      }
     }
   ];
 };

--- a/src/components/molecules/tables/TransferOrderTable/columns/TOColumns.tsx
+++ b/src/components/molecules/tables/TransferOrderTable/columns/TOColumns.tsx
@@ -205,8 +205,7 @@ export const columns = (
         row
       ) => {
         const hoursUntilTrip = dayjs(row.fechas.origin).diff(dayjs(), "hour");
-        const is24HoursOrLessToTrip =
-          (hoursUntilTrip >= 0 && hoursUntilTrip <= 24) || hoursUntilTrip < 0;
+        const is24HoursOrLessToTrip = hoursUntilTrip >= 0 && hoursUntilTrip <= 24;
 
         return (
           <div className="btnContainer">

--- a/src/components/molecules/tables/TransferOrderTable/columns/transferOrderTable.scss
+++ b/src/components/molecules/tables/TransferOrderTable/columns/transferOrderTable.scss
@@ -41,6 +41,7 @@
     display: flex;
     justify-content: flex-end;
     column-gap: 8px;
+    align-items: center;
 
     .btn {
         background-color: #f7f7f7;


### PR DESCRIPTION
<img width="1431" height="475" alt="image" src="https://github.com/user-attachments/assets/b253d1eb-1051-4539-b5bc-53aad6171ed2" />
This pull request enhances the `TransferOrderTable` component by adding a new visual indicator for trips starting within 24 hours, along with minor styling adjustments. The most important changes include introducing a new warning icon with a tooltip, updating the column rendering logic, and refining the table's button alignment.

### Functional updates:

* **New warning icon for imminent trips**: Added a `WarningCircle` icon with a red color and a tooltip to indicate when a trip is starting in less than 24 hours or is overdue. This logic was integrated into the `columns` definition in `TOColumns.tsx`. [[1]](diffhunk://#diff-67ca9727fb0589621dcd6255d318818cef12ad3e8f4bd878126bf7b924d2db8aL198-R211) [[2]](diffhunk://#diff-67ca9727fb0589621dcd6255d318818cef12ad3e8f4bd878126bf7b924d2db8aR231-R248)

### Styling updates:

* **Button alignment improvement**: Updated the `.btnContainer` CSS in `transferOrderTable.scss` to align buttons vertically by adding `align-items: center`.

### Dependency updates:

* **Icon imports**: Added the `WarningCircle` icon from the `@phosphor-icons/react` library to support the new warning indicator.