### PR TITLE
Enhance TransferOrderTable to show warnings for trips starting within…

### DIFF
--- a/src/components/molecules/tables/TransferOrderTable/columns/TOColumns.tsx
+++ b/src/components/molecules/tables/TransferOrderTable/columns/TOColumns.tsx
@@ -1,17 +1,19 @@
+import Link from "next/link";
 import { Button, Flex, TableColumnsType, Tooltip, Typography } from "antd";
-import { DataTypeForTransferOrderTable } from "../TransferOrderTable";
-import { calculateMinutesDifference } from "@/utils/logistics/calculateMinutesDifference";
-import { Eye, Warning, WarningOctagon } from "phosphor-react";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import { Eye, Radioactive, Warning, WarningCircle, WarningOctagon } from "@phosphor-icons/react";
+
+import { calculateMinutesDifference } from "@/utils/logistics/calculateMinutesDifference";
 import { formatMoney, formatTimeAgo } from "@/utils/utils";
-import { Radioactive, WarningCircle } from "@phosphor-icons/react";
+import { STATUS } from "@/utils/constants/globalConstants";
+
+import { DataTypeForTransferOrderTable } from "../TransferOrderTable";
+
 import "./transferOrderTable.scss";
-import Link from "next/link";
+const { Text } = Typography;
 
 dayjs.extend(utc);
-
-const { Text } = Typography;
 
 export const columns = (
   showColumn: boolean,
@@ -204,8 +206,17 @@ export const columns = (
         },
         row
       ) => {
-        const hoursUntilTrip = dayjs(row.fechas.origin).diff(dayjs(), "hour");
+        const tripDate = dayjs(row.fechas.origin);
+        const now = dayjs();
+
+        const isSameDay = tripDate.isSame(now, "day");
+        const hoursUntilTrip = tripDate.diff(now, "hour");
         const is24HoursOrLessToTrip = hoursUntilTrip >= 0 && hoursUntilTrip <= 24;
+
+        // warning only appear in certain states
+        const showWarning =
+          (isSameDay || is24HoursOrLessToTrip) &&
+          allowedStatesForWarningTrips.includes(row.statusId);
 
         return (
           <div className="btnContainer">
@@ -228,7 +239,7 @@ export const columns = (
               <Button className="btn" type="text" size="middle" icon={<Warning size={24} />} />
             )}
 
-            {is24HoursOrLessToTrip && (
+            {showWarning && (
               <Tooltip title="Este viaje inicia en menos de 24 horas">
                 <Button
                   className="btn"
@@ -248,3 +259,9 @@ export const columns = (
     }
   ];
 };
+
+const allowedStatesForWarningTrips = [
+  STATUS.TO.SIN_PROCESAR,
+  STATUS.TR.ESPERANDO_PROVEEDOR,
+  STATUS.TR.ASIGNANDO_VEHICULO
+];


### PR DESCRIPTION
This pull request refines the logic for displaying warning icons in the `TransferOrderTable` by ensuring that the warning only appears for trips within 24 hours and in specific allowed states. The changes also clean up imports and improve code clarity.

**Improvements to warning icon logic:**

* Added logic to only show the warning icon if the trip is on the same day or within 24 hours and the transfer order is in an allowed state, using the new `allowedStatesForWarningTrips` array. [[1]](diffhunk://#diff-67ca9727fb0589621dcd6255d318818cef12ad3e8f4bd878126bf7b924d2db8aL207-R220) [[2]](diffhunk://#diff-67ca9727fb0589621dcd6255d318818cef12ad3e8f4bd878126bf7b924d2db8aL231-R242) [[3]](diffhunk://#diff-67ca9727fb0589621dcd6255d318818cef12ad3e8f4bd878126bf7b924d2db8aR262-R267)

**Code cleanup and organization:**

* Cleaned up and reorganized imports in `TOColumns.tsx` for better readability and to remove duplicates.