### PR TITLE
Enhance CarrierRequestProposal with links for vehicle and driver deta…

### DIFF
--- a/src/components/organisms/logistics/orders/transfer_request/components/carrierRequest/CarrierRequestProposal.tsx
+++ b/src/components/organisms/logistics/orders/transfer_request/components/carrierRequest/CarrierRequestProposal.tsx
@@ -1,8 +1,9 @@
-import { Checkbox, Collapse, Flex, Radio, Tag, Typography } from "antd";
+import { Collapse, Flex, Radio, Tag, Typography } from "antd";
 import style from "./CarrierRequestProposal.module.scss";
-import { CarriersPricing, TripCarriersPricing } from "@/types/logistics/schema";
+import { CarriersPricing } from "@/types/logistics/schema";
 import { CollapseProps } from "antd/lib";
 import { Star } from "phosphor-react";
+import Link from "next/link";
 
 const { Title, Text } = Typography;
 
@@ -22,10 +23,22 @@ export default function CarrierRequestProposal({ carrier }: Props) {
       <Flex gap={24} className={style.children}>
         <Flex gap={10} vertical>
           <Flex justify="space-between">
-            <strong>Placas</strong> <div>{carrier.plate_number}</div>
+            <strong>Placas</strong>{" "}
+            <Link
+              href={`/logistics/providers/${carrier.id_carrier}/vehicle/${carrier.id_vehicle}`}
+              target="_blank"
+            >
+              {carrier.plate_number}
+            </Link>
           </Flex>
           <Flex justify="space-between">
-            <strong>Conductor</strong> <div>{carrier.driver}</div>
+            <strong>Conductor</strong>{" "}
+            <Link
+              href={`/logistics/providers/${carrier.id_carrier}/driver/${carrier.driver_id}`}
+              target="_blank"
+            >
+              {carrier.driver}
+            </Link>
           </Flex>
           <Flex justify="space-between">
             <strong>Teléfono</strong> <div>{carrier.phone}</div>

--- a/src/components/organisms/logistics/orders/transfer_request/components/trip/TripCarrierPricing.tsx
+++ b/src/components/organisms/logistics/orders/transfer_request/components/trip/TripCarrierPricing.tsx
@@ -1,8 +1,7 @@
 import { TripCarriersPricing } from "@/types/logistics/schema";
-import { Flex, Radio, Space, Typography } from "antd";
+import { Flex, Radio, Typography } from "antd";
 import style from "./TripCarrierPricing.module.scss";
 import CarrierRequestProposal from "../carrierRequest/CarrierRequestProposal";
-import { useState } from "react";
 import { CarrierPricingFinish } from "@/types/logistics/transferRequest/transferRequest";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";

--- a/src/types/logistics/schema.ts
+++ b/src/types/logistics/schema.ts
@@ -2057,6 +2057,7 @@ export interface CarriersPricing {
   driver_delay: number;
   diver_trips: number;
   driver_score: number;
+  driver_id: number;
   id: number;
   id_carrier: number;
   id_service_type: number;


### PR DESCRIPTION
…ils; update CarriersPricing interface to include driver_id
This pull request enhances the `CarrierRequestProposal` component by making vehicle plate numbers and driver names clickable links to their respective detail pages, and introduces a minor schema update to support this feature. It also includes some cleanup of unused imports.

**Feature enhancements:**

* Made the vehicle plate number and driver name in `CarrierRequestProposal` clickable links that open the vehicle and driver detail pages in a new tab, using the carrier and vehicle/driver IDs.

**Schema and import updates:**

* Added a new `driver_id` field to the `CarriersPricing` interface in `schema.ts` to enable linking to the driver detail page.
* Removed unused imports (`Checkbox` from Ant Design and `TripCarriersPricing` type) from `CarrierRequestProposal.tsx` and `TripCarrierPricing.tsx` for code cleanliness. [[1]](diffhunk://#diff-dc60a1ee0143ac49b2b312e066fe610cd206bfcdf4bfefd37910081f42240d7cL1-R6) [[2]](diffhunk://#diff-1c8ce7d318a3f5c021ec07aec4c2580506197d432feb0ac80f9c852c37ccd93dL2-L5)