### PR TITLE
comment chat code from SideBar component

### DIFF
--- a/src/components/molecules/SideBar/SideBar.tsx
+++ b/src/components/molecules/SideBar/SideBar.tsx
@@ -284,7 +284,7 @@ export const SideBar = () => {
             </Button>
           </Link>
         )}
-        {true && (
+        {/* {true && (
           <Link href="/chat" passHref legacyBehavior>
             <Button
               type="primary"
@@ -295,7 +295,7 @@ export const SideBar = () => {
               {isSideBarLarge && "Ajustes"}
             </Button>
           </Link>
-        )}
+        )} */}
       </Flex>
       <Flex className="exit">
         <Button


### PR DESCRIPTION
This pull request makes a minor change to the `SideBar` component by commenting out the code that renders the "Ajustes" button and its link to the `/chat` route. This effectively hides the "Ajustes" button from the sidebar UI.