### PR TITLE
Refactor CreateOrder components to enforce stricter type definitions …

### DIFF
--- a/src/components/atoms/SelectableIconButtons/SelectableIconButtons.tsx
+++ b/src/components/atoms/SelectableIconButtons/SelectableIconButtons.tsx
@@ -4,7 +4,7 @@ import { Flex } from "antd";
 import "./selectableIconButtons.scss";
 
 export type TripTypeOption = {
-  id: string;
+  id: "1" | "2" | "3";
   title: string;
   icon: React.ReactNode;
 };
@@ -13,15 +13,19 @@ interface SelectableIconButtonsProps {
   options: TripTypeOption[];
   activeId?: string;
   // eslint-disable-next-line no-unused-vars
-  onChange: (id: string) => void;
+  onChange: (id: "1" | "2" | "3") => void;
   className?: string;
+  disabled?: boolean;
+  allInactive?: boolean; // Nuevo prop
 }
 
 const SelectableIconButtons: React.FC<SelectableIconButtonsProps> = ({
   options,
   activeId,
   onChange,
-  className
+  className,
+  disabled,
+  allInactive = false // Valor por defecto
 }) => {
   return (
     <Flex gap="1rem" className={className} style={{ flexWrap: "wrap" }}>
@@ -29,8 +33,12 @@ const SelectableIconButtons: React.FC<SelectableIconButtonsProps> = ({
         <button
           key={option.id}
           type="button"
-          className={["iconButton", activeId === option.id ? "active" : undefined].join(" ")}
+          className={[
+            "iconButton",
+            !allInactive && activeId === option.id ? "active" : undefined
+          ].join(" ")}
           onClick={() => onChange(option.id)}
+          disabled={disabled}
         >
           {option.icon}
           <div className="text">{option.title}</div>

--- a/src/components/organisms/logistics/orders/CreateOrderVieww/CreateOrderVieww.mapper.ts
+++ b/src/components/organisms/logistics/orders/CreateOrderVieww/CreateOrderVieww.mapper.ts
@@ -165,7 +165,7 @@ export const mapFormToTransferOrder = (formData: IFormCreateOrder): IAddTransfer
     end_date_flexible: "0",
     id_route: "", // Vacío por defecto
     id_company: formData.billing?.companyCode?.id?.toString() || "1",
-    isFixedRate: formData.typeActive === "4" ? "1" : "0",
+    isFixedRate: formData.isFixRate ? "1" : "0",
     status: "",
     active: "true",
     created_at: new Date().toISOString(),

--- a/src/components/organisms/logistics/orders/CreateOrderVieww/CreateOrderVieww.tsx
+++ b/src/components/organisms/logistics/orders/CreateOrderVieww/CreateOrderVieww.tsx
@@ -96,8 +96,9 @@ interface IProductServiceLineForm {
 }
 
 export interface IFormCreateOrder {
-  typeActive: string; // "1" | "2" | "3" | "4"
+  typeActive: "1" | "2" | "3";
   TripDetails: ITripForm[]; // [Origen, ...paradas, Destino]
+  isFixRate: boolean;
   geometry: IRoute[]; // en el submit se manda  todo esto
   material?: IMaterialForm[];
   people?: IPeopleForm[];
@@ -153,10 +154,9 @@ export const CreateOrderVieww: React.FC = () => {
     }
   });
 
-  // watchTripType
   const tripType = watch("typeActive");
-  // Watch the TripDetails to see if any changes are made
   const tripDetails = watch("TripDetails");
+  const isFixRate = watch("isFixRate");
 
   // watch Load form values
   const materialDetails = watch("material");
@@ -218,9 +218,7 @@ export const CreateOrderVieww: React.FC = () => {
     // for every view we check if the next button should be disabled
     switch (view) {
       case "scheduling":
-        const isDestinationDateAndTimeMandatory = tripType === "4";
-
-        if (isDestinationDateAndTimeMandatory) {
+        if (isFixRate) {
           const isValid = tripDetails.every(
             (detail) => detail.placeId && detail.date && detail.time
           );
@@ -251,8 +249,8 @@ export const CreateOrderVieww: React.FC = () => {
 
         const validOtherServices = otherServices?.every((service) => service.id !== undefined);
 
-        // Type 4 only needs vehicle validation
-        if (tripType === "4") {
+        // If fix rateneeds vehicle validation
+        if (isFixRate) {
           return !validVehicles || !validOtherServices;
         }
 

--- a/src/components/organisms/logistics/orders/CreateOrderVieww/components/LoadView/SuggestedVehicleSection/SuggestedVehicleSection.tsx
+++ b/src/components/organisms/logistics/orders/CreateOrderVieww/components/LoadView/SuggestedVehicleSection/SuggestedVehicleSection.tsx
@@ -136,7 +136,6 @@ const SuggestedVehicleSection: React.FC<ISuggestedVehicleSectionProps> = ({ cont
 
     switch (typeActive) {
       case "1":
-      case "4":
         return vehicle.ocupationM3 || 0;
       case "2":
         return vehicle.ocupationKg || 0;

--- a/src/components/organisms/logistics/orders/CreateOrderVieww/components/SchedulingView/SchedulingView.tsx
+++ b/src/components/organisms/logistics/orders/CreateOrderVieww/components/SchedulingView/SchedulingView.tsx
@@ -57,6 +57,7 @@ const SchedulingView: React.FC<SchedulingViewProps> = ({ control, setValue, rese
   const [locationOptions, setLocationOptions] = useState<ISelectLocation[]>([]);
   const typeActive = useWatch({ control, name: "typeActive" });
   const tripDetails = useWatch({ control, name: "TripDetails" }) ?? [];
+  const [isFixRate, setIsFixRate] = useState(false);
 
   const timeBasedOnSelectedDateTimeHours = useMemo(() => {
     if (typeActive === "2") {
@@ -371,7 +372,7 @@ const SchedulingView: React.FC<SchedulingViewProps> = ({ control, setValue, rese
     }
   };
 
-  const handleOrderTypeChange = (id: string) => {
+  const handleOrderTypeChange = (id: "1" | "2" | "3") => {
     setValue("typeActive", id);
     const emptyValue = [{ id: undefined, quantity: 1 }];
     resetField("material", {
@@ -392,11 +393,34 @@ const SchedulingView: React.FC<SchedulingViewProps> = ({ control, setValue, rese
     <div className="schedulingView">
       {/* Form */}
       <Flex vertical gap={"1.5rem"} style={{ paddingLeft: "1rem" }}>
-        <SelectableIconButtons
-          options={tripTypeOptions}
-          activeId={typeActive}
-          onChange={handleOrderTypeChange}
-        />
+        <Flex gap="1rem" align="center">
+          <SelectableIconButtons
+            options={tripTypeOptions}
+            activeId={typeActive}
+            onChange={handleOrderTypeChange}
+            disabled={isFixRate}
+            allInactive={isFixRate}
+          />
+          <button
+            type="button"
+            className={`iconButton ${isFixRate ? "active" : ""}`}
+            onClick={() => {
+              setIsFixRate(!isFixRate);
+              setValue("isFixRate", !isFixRate);
+            }}
+          >
+            <Calendar size={24} />
+            <div className="text">Renta fija</div>
+          </button>
+        </Flex>
+
+        {isFixRate && (
+          <SelectableIconButtons
+            options={tripTypeOptions}
+            activeId={typeActive}
+            onChange={handleOrderTypeChange}
+          />
+        )}
 
         <SelectLocationAndTime
           selectedType={typeActive}
@@ -449,10 +473,5 @@ const tripTypeOptions: TripTypeOption[] = [
     id: "3",
     title: "Personal",
     icon: <User size={24} />
-  },
-  {
-    id: "4",
-    title: "Renta fija",
-    icon: <Calendar size={24} />
   }
 ];


### PR DESCRIPTION
…and introduce isFixRate functionality for improved order handling
This pull request refactors the handling of trip types and the "fixed rate" (renta fija) option across the order creation flow. The main changes include removing the "4" trip type in favor of a dedicated `isFixRate` boolean, updating types and logic accordingly, and improving the UI to clearly separate fixed rate selection from trip type selection.

**Refactoring trip type and fixed rate handling:**

* The `TripTypeOption` type and related props now only accept `"1"`, `"2"`, or `"3"` as valid IDs, removing the previous `"4"` value for "fixed rate". The `isFixRate` boolean is introduced to represent the fixed rate option separately. (`src/components/atoms/SelectableIconButtons/SelectableIconButtons.tsx` [[1]](diffhunk://#diff-62a95c5db5312c7e317f3b558d47a1182a638d6c762f1d1e251702e1ea807243L7-R7) [[2]](diffhunk://#diff-62a95c5db5312c7e317f3b558d47a1182a638d6c762f1d1e251702e1ea807243L16-R41); `src/components/organisms/logistics/orders/CreateOrderVieww/CreateOrderVieww.tsx` [[3]](diffhunk://#diff-390c88ac1f2adacb94c46c9393e3cf3accb87430a396b32fbddc859685780ff5L99-R101)
* The UI for selecting "Renta fija" (fixed rate) is now a distinct button, and when selected, disables the trip type buttons and visually indicates the fixed rate state. (`src/components/organisms/logistics/orders/CreateOrderVieww/components/SchedulingView/SchedulingView.tsx` [[1]](diffhunk://#diff-973a88dd6778fd82ab2a398c5bda5364536ce7d166a9ee0a0681d54116b7ab97R396-R423) [[2]](diffhunk://#diff-973a88dd6778fd82ab2a398c5bda5364536ce7d166a9ee0a0681d54116b7ab97L452-L456)

**Type and logic updates:**

* All references to the `"4"` trip type are removed or replaced with logic based on `isFixRate`, including validation and mapping functions. (`src/components/organisms/logistics/orders/CreateOrderVieww/CreateOrderVieww.mapper.ts` [[1]](diffhunk://#diff-5d6ca705832cf77487f8c73e400fd9783f30e201ed4989ec6c4c1443238031f4L168-R168); `src/components/organisms/logistics/orders/CreateOrderVieww/CreateOrderVieww.tsx` [[2]](diffhunk://#diff-390c88ac1f2adacb94c46c9393e3cf3accb87430a396b32fbddc859685780ff5L156-R159) [[3]](diffhunk://#diff-390c88ac1f2adacb94c46c9393e3cf3accb87430a396b32fbddc859685780ff5L221-R221) [[4]](diffhunk://#diff-390c88ac1f2adacb94c46c9393e3cf3accb87430a396b32fbddc859685780ff5L254-R253); `src/components/organisms/logistics/orders/CreateOrderVieww/components/LoadView/SuggestedVehicleSection/SuggestedVehicleSection.tsx` [[5]](diffhunk://#diff-bf414b2345d905268d1c891c05dbea9a231229d9b100fb25c06781f36c0d8f39L139)
* The `SelectableIconButtons` component and related handlers are updated to use the narrowed trip type and new prop types. (`src/components/atoms/SelectableIconButtons/SelectableIconButtons.tsx` [[1]](diffhunk://#diff-62a95c5db5312c7e317f3b558d47a1182a638d6c762f1d1e251702e1ea807243L7-R7) [[2]](diffhunk://#diff-62a95c5db5312c7e317f3b558d47a1182a638d6c762f1d1e251702e1ea807243L16-R41); `src/components/organisms/logistics/orders/CreateOrderVieww/components/SchedulingView/SchedulingView.tsx` [[3]](diffhunk://#diff-973a88dd6778fd82ab2a398c5bda5364536ce7d166a9ee0a0681d54116b7ab97L374-R375)

**UI/UX improvements:**

* The fixed rate button and trip type buttons are grouped together for clarity, and when fixed rate is active, the trip type selection is visually and functionally disabled. (`src/components/organisms/logistics/orders/CreateOrderVieww/components/SchedulingView/SchedulingView.tsx` [src/components/organisms/logistics/orders/CreateOrderVieww/components/SchedulingView/SchedulingView.tsxR396-R423](diffhunk://#diff-973a88dd6778fd82ab2a398c5bda5364536ce7d166a9ee0a0681d54116b7ab97R396-R423))
* The option for "Renta fija" is removed from the main trip type options array, reflecting its new status as a separate toggle. (`src/components/organisms/logistics/orders/CreateOrderVieww/components/SchedulingView/SchedulingView.tsx` [src/components/organisms/logistics/orders/CreateOrderVieww/components/SchedulingView/SchedulingView.tsxL452-L456](diffhunk://#diff-973a88dd6778fd82ab2a398c5bda5364536ce7d166a9ee0a0681d54116b7ab97L452-L456))