### PR TITLE
Fix/booking fixes

### DIFF
--- a/src/components/organisms/logistics/orders/CreateOrderVieww/components/LoadView/MaterialSection/MaterialSection.tsx
+++ b/src/components/organisms/logistics/orders/CreateOrderVieww/components/LoadView/MaterialSection/MaterialSection.tsx
@@ -47,6 +47,18 @@ const MaterialSection: React.FC<IMaterialSectionProps> = ({ control }) => {
       name: "material"
     }) || [];
 
+  const calculateVolume = (height?: number, width?: number, length?: number): number => {
+    const h = height || 0;
+    const w = width || 0;
+    const l = length || 0;
+    return h * w * l;
+  };
+
+  const formatVolume = (volume: number): string => {
+    if (volume === 0) return "--";
+    return `${volume.toFixed(3)} m³`;
+  };
+
   useEffect(() => {
     (async () => {
       const res = await getAllMaterials();
@@ -115,13 +127,16 @@ const MaterialSection: React.FC<IMaterialSectionProps> = ({ control }) => {
                   update(index, {
                     ...fields[index],
                     ...found,
-                    id: found.id
+                    id: found.id,
+                    // Calcular el volumen inicial si tiene dimensiones
+                    m3_volume: calculateVolume(found.mt_height, found.mt_width, found.mt_length)
                   });
                 } else {
                   // Limpia la fila si se deselecciona
                   update(index, {
                     ...fields[index],
-                    id: undefined
+                    id: undefined,
+                    m3_volume: 0
                   });
                 }
               }}
@@ -190,6 +205,21 @@ const MaterialSection: React.FC<IMaterialSectionProps> = ({ control }) => {
                 // Aseguramos que siempre sea algo valido
                 const numericValue = val === null || val === undefined ? 0 : Number(val);
                 onChange(numericValue);
+
+                // Actualizar el volumen cuando cambia el alto
+                const currentRow = selectedMaterials[index];
+                if (currentRow) {
+                  const newVolume = calculateVolume(
+                    numericValue,
+                    currentRow.mt_width,
+                    currentRow.mt_length
+                  );
+                  update(index, {
+                    ...currentRow,
+                    mt_height: numericValue,
+                    m3_volume: newVolume
+                  });
+                }
               }}
               min={0}
               step={0.01}
@@ -229,6 +259,21 @@ const MaterialSection: React.FC<IMaterialSectionProps> = ({ control }) => {
                 // Aseguramos que siempre sea algo valido
                 const numericValue = val === null || val === undefined ? 0 : Number(val);
                 onChange(numericValue);
+
+                // Actualizar el volumen cuando cambia el ancho
+                const currentRow = selectedMaterials[index];
+                if (currentRow) {
+                  const newVolume = calculateVolume(
+                    currentRow.mt_height,
+                    numericValue,
+                    currentRow.mt_length
+                  );
+                  update(index, {
+                    ...currentRow,
+                    mt_width: numericValue,
+                    m3_volume: newVolume
+                  });
+                }
               }}
               min={0}
               step={0.01}
@@ -268,6 +313,21 @@ const MaterialSection: React.FC<IMaterialSectionProps> = ({ control }) => {
                 // Aseguramos que siempre sea algo valido
                 const numericValue = val === null || val === undefined ? 0 : Number(val);
                 onChange(numericValue);
+
+                // Actualizar el volumen cuando cambia el largo
+                const currentRow = selectedMaterials[index];
+                if (currentRow) {
+                  const newVolume = calculateVolume(
+                    currentRow.mt_height,
+                    currentRow.mt_width,
+                    numericValue
+                  );
+                  update(index, {
+                    ...currentRow,
+                    mt_length: numericValue,
+                    m3_volume: newVolume
+                  });
+                }
               }}
               min={0}
               step={0.01}
@@ -295,7 +355,14 @@ const MaterialSection: React.FC<IMaterialSectionProps> = ({ control }) => {
       title: "Volumen",
       dataIndex: "m3_volume",
       key: "m3_volume",
-      render: (volume) => <span>{volume ? `${volume} m³` : "--"}</span>
+      render: (_: any, __: any, index: number) => {
+        const height = selectedMaterials[index]?.mt_height;
+        const width = selectedMaterials[index]?.mt_width;
+        const length = selectedMaterials[index]?.mt_length;
+
+        const volume = calculateVolume(height, width, length);
+        return <span>{formatVolume(volume)}</span>;
+      }
     },
     {
       title: "S. Controladas",

--- a/src/components/organisms/logistics/orders/CreateOrderVieww/components/LoadView/SuggestedVehicleSection/SuggestedVehicleSection.tsx
+++ b/src/components/organisms/logistics/orders/CreateOrderVieww/components/LoadView/SuggestedVehicleSection/SuggestedVehicleSection.tsx
@@ -136,7 +136,10 @@ const SuggestedVehicleSection: React.FC<ISuggestedVehicleSectionProps> = ({ cont
 
     switch (typeActive) {
       case "1":
-        return vehicle.ocupationM3 || 0;
+        return (
+          (vehicle.ocupationM3 > vehicle.ocupationKg ? vehicle.ocupationM3 : vehicle.ocupationKg) ||
+          0
+        );
       case "2":
         return vehicle.ocupationKg || 0;
       case "3":


### PR DESCRIPTION
This pull request introduces improvements to the volume calculation and display logic for materials in the order creation view, ensuring that the volume (`m3_volume`) is always up-to-date when dimensions change, and enhancing the presentation of volume values. Additionally, it updates the suggested vehicle section to more accurately select the occupation value based on the active type.

**Material volume calculation and display:**

* Added `calculateVolume` and `formatVolume` helper functions to centralize and standardize how material volume is calculated and displayed in `MaterialSection.tsx`.
* Updated logic to recalculate and update `m3_volume` whenever material dimensions (`mt_height`, `mt_width`, `mt_length`) are changed by the user, ensuring the displayed value is always accurate. [[1]](diffhunk://#diff-6ea8f4e5059b37d6ac8ec7dfb263e6a71ce4082aecfd188233f00755b6f77798R208-R222) [[2]](diffhunk://#diff-6ea8f4e5059b37d6ac8ec7dfb263e6a71ce4082aecfd188233f00755b6f77798R262-R276) [[3]](diffhunk://#diff-6ea8f4e5059b37d6ac8ec7dfb263e6a71ce4082aecfd188233f00755b6f77798R316-R330)
* Improved the volume rendering in the materials table to use the new helper functions, showing a formatted string or a placeholder when dimensions are missing.
* Ensured that when a material is deselected, its volume is reset to zero for clarity.

**Suggested vehicle logic:**

* Modified the occupation value selection in `SuggestedVehicleSection.tsx` to use the greater of `ocupationM3` or `ocupationKg` when type "1" is active, providing a more accurate suggestion.