### PR TITLE
Feat/add password character validation

### DIFF
--- a/src/components/molecules/login/ChangePassForm/ChangePassForm.tsx
+++ b/src/components/molecules/login/ChangePassForm/ChangePassForm.tsx
@@ -17,15 +17,27 @@ interface IChangePassForm {
   confirmPassword: string;
 }
 
+interface IChangePassFormProps {
+  mode: "accept" | "change";
+}
+
 const schema = yup.object().shape({
-  password: yup.string().min(5).max(32).required(),
+  password: yup
+    .string()
+    .min(8, "La contraseña debe tener al menos 8 caracteres")
+    .max(32, "La contraseña no puede tener más de 32 caracteres")
+    .matches(/[a-z]/, "La contraseña debe contener al menos una minúscula")
+    .matches(/[A-Z]/, "La contraseña debe contener al menos una mayúscula")
+    .matches(/\d/, "La contraseña debe contener al menos un número")
+    .matches(/[!@#$%^&*(),.?":{}|<>]/, "La contraseña debe contener al menos un carácter especial")
+    .required(),
   confirmPassword: yup
     .string()
     .oneOf([yup.ref("password")], "Las contraseñas no coinciden")
     .required()
 });
 
-export const ChangePassForm = ({ mode }: { mode: "accept" | "change" }) => {
+export const ChangePassForm = ({ mode }: IChangePassFormProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const searchParams = useSearchParams();
   const oobCode = searchParams.get("oobCode");
@@ -104,41 +116,45 @@ export const ChangePassForm = ({ mode }: { mode: "accept" | "change" }) => {
             control={control}
             rules={{ required: true }}
             render={({ field }) => (
-              <Input
-                size="large"
-                type={showPassword.password ? "text" : "password"}
-                className="inputPassword"
-                placeholder="Contrasena"
-                variant="borderless"
-                required
-                autoComplete="current-password"
-                suffix={
-                  <Tooltip title={showPassword.password ? "Hidden Password" : "Show Password"}>
-                    {!showPassword.password ? (
-                      <Eye
-                        onClick={() => {
-                          setShowPassword((prevState) => ({
-                            ...prevState,
-                            password: true
-                          }));
-                        }}
-                        className="iconEyePassword"
-                      />
-                    ) : (
-                      <EyeClosed
-                        onClick={() => {
-                          setShowPassword((prevState) => ({
-                            ...prevState,
-                            password: false
-                          }));
-                        }}
-                        className="iconEyePassword"
-                      />
-                    )}
-                  </Tooltip>
-                }
-                {...field}
-              />
+              <>
+                <Input
+                  size="large"
+                  type={showPassword.password ? "text" : "password"}
+                  className="inputPassword"
+                  placeholder="Contrasena"
+                  variant="borderless"
+                  required
+                  autoComplete="current-password"
+                  suffix={
+                    <Tooltip title={showPassword.password ? "Hidden Password" : "Show Password"}>
+                      {!showPassword.password ? (
+                        <Eye
+                          onClick={() => {
+                            setShowPassword((prevState) => ({
+                              ...prevState,
+                              password: true
+                            }));
+                          }}
+                          className="iconEyePassword"
+                        />
+                      ) : (
+                        <EyeClosed
+                          onClick={() => {
+                            setShowPassword((prevState) => ({
+                              ...prevState,
+                              password: false
+                            }));
+                          }}
+                          className="iconEyePassword"
+                        />
+                      )}
+                    </Tooltip>
+                  }
+                  {...field}
+                />
+
+                {errors.password && <div className="errorMessage">{errors.password.message}</div>}
+              </>
             )}
           />
         </div>

--- a/src/components/molecules/login/ChangePassForm/ChangePassForm.tsx
+++ b/src/components/molecules/login/ChangePassForm/ChangePassForm.tsx
@@ -125,6 +125,18 @@ export const ChangePassForm = ({ mode }: IChangePassFormProps) => {
                   variant="borderless"
                   required
                   autoComplete="current-password"
+                  onPaste={(e) => {
+                    e.preventDefault();
+                    return false;
+                  }}
+                  onCopy={(e) => {
+                    e.preventDefault();
+                    return false;
+                  }}
+                  onCut={(e) => {
+                    e.preventDefault();
+                    return false;
+                  }}
                   suffix={
                     <Tooltip title={showPassword.password ? "Hidden Password" : "Show Password"}>
                       {!showPassword.password ? (
@@ -174,6 +186,18 @@ export const ChangePassForm = ({ mode }: IChangePassFormProps) => {
                   variant="borderless"
                   required
                   autoComplete="current-password"
+                  onPaste={(e) => {
+                    e.preventDefault();
+                    return false;
+                  }}
+                  onCopy={(e) => {
+                    e.preventDefault();
+                    return false;
+                  }}
+                  onCut={(e) => {
+                    e.preventDefault();
+                    return false;
+                  }}
                   suffix={
                     <Tooltip
                       title={showPassword.confirmPassword ? "Hidden Password" : "Show Password"}

--- a/src/components/molecules/login/ChangePassForm/changePassForm.scss
+++ b/src/components/molecules/login/ChangePassForm/changePassForm.scss
@@ -29,6 +29,7 @@
             color: red;
             font-size: 0.875rem;
             margin-top: 0.5rem;
+            max-width: 365px;
         }
 
         .iconEyePassword {

--- a/src/components/organisms/auth/changePass/ChangePass.tsx
+++ b/src/components/organisms/auth/changePass/ChangePass.tsx
@@ -10,7 +10,7 @@ import { LogoCashport } from "@/components/atoms/logoCashport/LogoCashport";
 import { Suspense } from "react";
 import Loader from "@/components/atoms/loaders/loader";
 
-export const ChangePass = ({ mode }: { mode: 'accept' | 'change' }) => {
+export const ChangePass = ({ mode }: { mode: "accept" | "change" }) => {
   return (
     <main className={styles.containerChangePass}>
       <InfoCardLogin />


### PR DESCRIPTION
This pull request enhances the password change form by improving password validation, adding security measures to the password fields, and refining the user interface for error display. The changes focus on making password requirements clearer and preventing sensitive information from being copied or pasted.

**Password validation and security improvements:**

* Strengthened password validation in the `ChangePassForm` by requiring at least 8 characters, one lowercase, one uppercase, one number, and one special character, with specific error messages for each rule.
* Disabled copy, paste, and cut actions on both password and confirm password input fields to enhance security and prevent accidental exposure of passwords. [[1]](diffhunk://#diff-88fd462237d3baa53840e4a49855f43c6f690de37b4523f0b62c581d7d6c8f37R128-R139) [[2]](diffhunk://#diff-88fd462237d3baa53840e4a49855f43c6f690de37b4523f0b62c581d7d6c8f37R189-R200)

**User interface and code quality enhancements:**

* Displayed password validation error messages directly below the password input for better user feedback.
* Added a maximum width to error messages in the SCSS to ensure consistent layout.
* Refactored the `ChangePassForm` props to use a dedicated interface for better type safety and readability.

These updates collectively make the password change process more secure and user-friendly.