### PR TITLE
Enhance SummaryCard component: add isFixRate prop and update renderin…

### DIFF
--- a/src/components/organisms/logistics/orders/CreateOrderVieww/components/SchedulingView/SchedulingView.tsx
+++ b/src/components/organisms/logistics/orders/CreateOrderVieww/components/SchedulingView/SchedulingView.tsx
@@ -439,6 +439,7 @@ const SchedulingView: React.FC<SchedulingViewProps> = ({ control, setValue, rese
           duration={tripInfoMap?.duration}
           selectedTripType={typeActive}
           durationBasedOnSelects={timeBasedOnSelectedDateTimeHours}
+          isFixRate={isFixRate}
         />
       </Flex>
 

--- a/src/components/organisms/logistics/orders/CreateOrderVieww/components/SchedulingView/SummaryCard/SummaryCard.tsx
+++ b/src/components/organisms/logistics/orders/CreateOrderVieww/components/SchedulingView/SummaryCard/SummaryCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Flex } from "antd";
-import { Clock, Path } from "@phosphor-icons/react";
+import { CalendarDots, Clock, Path } from "@phosphor-icons/react";
 
 import { getTravelDuration } from "@/utils/logistics/maps";
 
@@ -9,18 +9,20 @@ import "./summaryCard.scss";
 interface ISummaryCardProps {
   distance?: number; // in meters
   duration?: number; // in seconds, optional for now
-  selectedTripType?: string;
+  selectedTripType?: "1" | "2" | "3";
   durationBasedOnSelects?: {
     days: number;
     hours: number;
   };
+  isFixRate?: boolean;
 }
 
 const SummaryCard: React.FC<ISummaryCardProps> = ({
   distance,
   duration,
   selectedTripType,
-  durationBasedOnSelects
+  durationBasedOnSelects,
+  isFixRate
 }) => {
   const hours = getTravelDuration(duration ?? 0);
 
@@ -33,11 +35,19 @@ const SummaryCard: React.FC<ISummaryCardProps> = ({
     <div className="summaryCard">
       <h2>Resumen del servicio</h2>
       <Flex gap={"1rem"}>
-        {selectedTripType === "2" || selectedTripType === "4" ? (
+        {isFixRate ? (
+          <Flex className="summaryCard__item">
+            <CalendarDots className="summaryCard__icon" size={32} />
+            <Flex vertical>
+              <p>Tiempo de renta</p>
+              <strong>{days > 0 ? `${days} días` : `${rentingHours} horas`}</strong>
+            </Flex>
+          </Flex>
+        ) : selectedTripType === "2" ? (
           <Flex className="summaryCard__item">
             <Path className="summaryCard__icon" size={32} />
             <Flex vertical>
-              <p>{selectedTripType === "2" ? "Tiempo de izaje" : "Tiempo de renta"}</p>
+              <p>Tiempo de izaje</p>
               <strong>{days > 0 ? `${days} días` : `${rentingHours} horas`}</strong>
             </Flex>
           </Flex>


### PR DESCRIPTION
…g logic for fixed rate display
<img width="1285" height="802" alt="image" src="https://github.com/user-attachments/assets/994acc32-948b-4129-b0ad-314a78fa6e63" />

This pull request updates the scheduling summary card component to better support fixed-rate trips and clarifies the trip type logic. The main changes involve adding a new `isFixRate` prop, updating type definitions, and improving how trip details are displayed based on the trip type and rate.

**Enhancements for fixed-rate trips and summary card logic:**

* Added a new `isFixRate` prop to both `SchedulingView` and `SummaryCard` components to explicitly handle fixed-rate trip scenarios. [[1]](diffhunk://#diff-973a88dd6778fd82ab2a398c5bda5364536ce7d166a9ee0a0681d54116b7ab97R442) [[2]](diffhunk://#diff-c65dc2ef5cb79957cdc0d8178c68af226f1f6b332610a48f98bcfb2905479008L12-R25)
* Updated the `selectedTripType` prop type in `SummaryCard` to accept only `"1"`, `"2"`, or `"3"` for stricter type safety.
* Improved the summary card display logic: when `isFixRate` is true, the card now shows rental time with a calendar icon; otherwise, it displays trip-specific information based on `selectedTripType`.
* Added the `CalendarDots` icon to visually represent rental time in the summary card.