### PR TITLE
Fix/accept carrier next button validation

### DIFF
--- a/src/components/organisms/logistics/acept_carrier/detail/components/SolicitationDetail/SolicitationDetail.tsx
+++ b/src/components/organisms/logistics/acept_carrier/detail/components/SolicitationDetail/SolicitationDetail.tsx
@@ -164,7 +164,11 @@ export default function SolicitationDetail({
       )}
       <Buttons
         canContinue={true}
-        isRightButtonActive={true}
+        isRightButtonActive={
+          providerDetail?.isAuction && formMode === FormMode.CREATE
+            ? !!(quote?.amount && quote?.files && quote.files.length > 0)
+            : true
+        }
         isLeftButtonActive={true}
         handleNext={() => {
           if (entityType === "otherRequirement") {


### PR DESCRIPTION
This pull request updates the logic for enabling the right button in the `SolicitationDetail` component. The button is now only active during auction creation if both a quote amount and at least one file are provided; otherwise, it remains always active as before.

- Button activation logic:
  * Updated the `isRightButtonActive` prop in `SolicitationDetail` so that, for auctions in create mode, the right button is only enabled if a quote amount is entered and at least one file is attached. In all other cases, the button remains enabled.