### PR TITLE
Fix/let duplicate materials in create to

### DIFF
--- a/src/components/organisms/logistics/orders/CreateOrderVieww/components/LoadView/MaterialSection/MaterialSection.tsx
+++ b/src/components/organisms/logistics/orders/CreateOrderVieww/components/LoadView/MaterialSection/MaterialSection.tsx
@@ -107,10 +107,7 @@ const MaterialSection: React.FC<IMaterialSectionProps> = ({ control, allMaterial
                 option ? option.label.toLowerCase().includes(input.toLowerCase()) : false
               }
               allowClear
-              options={materialOptions?.filter(
-                (option) =>
-                  !selectedMaterials.some((row, idx) => row.id === option.value && idx !== index)
-              )}
+              options={materialOptions}
               onChange={(value) => {
                 field.onChange(value);
                 // Al seleccionar, setea automáticamente todos los datos en la fila


### PR DESCRIPTION
<img width="1232" height="969" alt="image" src="https://github.com/user-attachments/assets/39baa2c5-bbae-4a14-8bed-112f050b7c7e" />

This pull request makes a targeted change to the material selection logic in the `MaterialSection` component. The filtering that previously prevented selecting the same material in multiple rows (except the current one) has been removed, so now all materials are always available in the dropdown options.

- Material selection dropdown now displays all available `materialOptions` without filtering out already-selected materials in other rows.