### PR TITLE
Hotfix/MaterialSection: Simplify material options filtering for imp…

### DIFF
--- a/src/components/organisms/logistics/orders/CreateOrderVieww/components/LoadView/MaterialSection/MaterialSection.tsx
+++ b/src/components/organisms/logistics/orders/CreateOrderVieww/components/LoadView/MaterialSection/MaterialSection.tsx
@@ -107,10 +107,7 @@ const MaterialSection: React.FC<IMaterialSectionProps> = ({ control, allMaterial
                 option ? option.label.toLowerCase().includes(input.toLowerCase()) : false
               }
               allowClear
-              options={materialOptions?.filter(
-                (option) =>
-                  !selectedMaterials.some((row, idx) => row.id === option.value && idx !== index)
-              )}
+              options={materialOptions}
               onChange={(value) => {
                 field.onChange(value);
                 // Al seleccionar, setea automáticamente todos los datos en la fila


### PR DESCRIPTION
…roved performance, allow duplicates
This pull request makes a small adjustment to the material selection dropdown in the `MaterialSection` component. The filtering logic that previously excluded already-selected materials (except for the current row) has been removed, so now all material options are shown in the dropdown.

* The `options` prop for the material selection dropdown in `MaterialSection.tsx` now displays all `materialOptions` without filtering out already-selected materials.