### PR TITLE
Fixes/fixesneApprovalForm

### DIFF
--- a/src/modules/logistics/approval/components/ComparativeAnalysis/ComparativeAnalysis.tsx
+++ b/src/modules/logistics/approval/components/ComparativeAnalysis/ComparativeAnalysis.tsx
@@ -11,21 +11,21 @@ import type { INewApprovalForm, ForecastItem, ComparisonRate } from "@/types/log
 interface ComparativeAnalysisProps {
   forecastItems: ForecastItem[];
   comparisonRates: Record<string, ComparisonRate[]>;
-  isSingleSource: boolean;
   control: Control<INewApprovalForm>;
   onRemoveComparisonRate: (forecastItemId: string, rateId: string) => void;
   onOpenModalCarrierPricing: (forecastItemId: string) => void;
   calculateGrandTotal: () => number;
+  tipoAprobacion: string;
 }
 
 export function ComparativeAnalysis({
   forecastItems,
   comparisonRates,
-  isSingleSource,
   control,
   onRemoveComparisonRate,
   onOpenModalCarrierPricing,
-  calculateGrandTotal
+  calculateGrandTotal,
+  tipoAprobacion
 }: ComparativeAnalysisProps) {
   // Local state for expanded accordion items
   const [expandedAnalysis, setExpandedAnalysis] = useState<Record<string, boolean>>({});
@@ -37,6 +37,12 @@ export function ComparativeAnalysis({
     });
   };
 
+  console.log("tipoAprobacion: string", tipoAprobacion);
+
+  if (tipoAprobacion !== "tarifa-recurrente") {
+    return null;
+  }
+
   return (
     <div className="mb-8 pb-8 border-t border-gray-200 pt-8">
       <h2 className="text-lg font-semibold text-gray-900 mb-6">Análisis comparativo</h2>
@@ -47,172 +53,147 @@ export function ComparativeAnalysis({
         </p>
       )}
 
-      {!isSingleSource && (
-        <div className="space-y-6 mb-6">
-          {forecastItems.map((item) => (
-            <div key={item.id} className="border border-gray-200 rounded-lg shadow-sm">
-              {/* Header for each forecast item */}
-              <div
-                className="flex items-center justify-between p-4 bg-gray-50 cursor-pointer hover:bg-gray-100 transition-colors"
-                onClick={() => toggleAnalysis(item.id)}
-              >
-                <div className="flex-1">
-                  <div className="flex items-center justify-between">
-                    <h3 className="font-semibold text-gray-900">{item.proveedor}</h3>
-                    <div className="text-right">
-                      <div className="text-lg font-bold text-gray-900">
-                        $ {item.tarifa.toLocaleString("es-CO")}
-                      </div>
-                      <div className="text-sm text-gray-600">
-                        {item.tipoVehiculo} • Km {item.descripcionTarifa}
-                      </div>
+      <div className="space-y-6 mb-6">
+        {forecastItems.map((item) => (
+          <div key={item.id} className="border border-gray-200 rounded-lg shadow-sm">
+            {/* Header for each forecast item */}
+            <div
+              className="flex items-center justify-between p-4 bg-gray-50 cursor-pointer hover:bg-gray-100 transition-colors"
+              onClick={() => toggleAnalysis(item.id)}
+            >
+              <div className="flex-1">
+                <div className="flex items-center justify-between">
+                  <h3 className="font-semibold text-gray-900">{item.proveedor}</h3>
+                  <div className="text-right">
+                    <div className="text-lg font-bold text-gray-900">
+                      $ {item.tarifa.toLocaleString("es-CO")}
+                    </div>
+                    <div className="text-sm text-gray-600">
+                      {item.tipoVehiculo} • Km {item.descripcionTarifa}
                     </div>
                   </div>
-                  <div className="text-sm text-gray-600 mt-1">
-                    Vendor: {item.vendor} Contrato: {item.contrato}
-                  </div>
                 </div>
-                <div className="ml-4">
-                  {expandedAnalysis[item.id] ? (
-                    <ChevronUp className="h-5 w-5 text-gray-500" />
-                  ) : (
-                    <ChevronDown className="h-5 w-5 text-gray-500" />
-                  )}
+                <div className="text-sm text-gray-600 mt-1">
+                  Vendor: {item.vendor} Contrato: {item.contrato}
                 </div>
               </div>
-
-              {/* Comparison table for forecast items */}
-              {expandedAnalysis[item.id] && (
-                <div className="p-4 bg-white">
-                  <div className="overflow-x-auto">
-                    <table className="w-full">
-                      <thead className="bg-gray-50 border-b border-gray-200">
-                        <tr>
-                          <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
-                            Proveedor
-                          </th>
-                          <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
-                            Tipo
-                          </th>
-                          <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
-                            Tipo vehículo
-                          </th>
-                          <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
-                            Tipo tarifa
-                          </th>
-                          <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
-                            Contrato
-                          </th>
-                          <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
-                            Tarifa
-                          </th>
-                          <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
-                            Diferencia
-                          </th>
-                          <th className="px-4 py-3"></th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y divide-gray-200">
-                        {(comparisonRates[item.id] || []).map((rate) => (
-                          <tr key={rate.id} className="hover:bg-gray-50">
-                            <td className="px-4 py-3">
-                              <span className="text-sm text-gray-900">{rate.proveedor || "-"}</span>
-                            </td>
-                            <td className="px-4 py-3">
-                              <span className="text-sm text-gray-900">{rate.tipo || "-"}</span>
-                            </td>
-                            <td className="px-4 py-3">
-                              <span className="text-sm text-gray-900">
-                                {rate.tipoVehiculo || "-"}
-                              </span>
-                            </td>
-                            <td className="px-4 py-3">
-                              <span className="text-sm text-gray-900">
-                                {rate.tipoTarifa || "-"}
-                              </span>
-                            </td>
-                            <td className="px-4 py-3">
-                              <span className="text-sm text-gray-900">{rate.contrato || "-"}</span>
-                            </td>
-                            <td className="px-4 py-3">
-                              <span className="text-sm font-medium text-gray-900">
-                                $ {rate.tarifa.toLocaleString("es-CO")}
-                              </span>
-                            </td>
-                            <td className="px-4 py-3">
-                              <span
-                                className={`text-sm font-medium ${
-                                  rate.diferencia > 0
-                                    ? "text-red-600"
-                                    : rate.diferencia < 0
-                                      ? "text-green-600"
-                                      : "text-gray-900"
-                                }`}
-                              >
-                                {(() => {
-                                  // Calculate percentage difference, protecting against division by zero
-                                  const percentage =
-                                    item.tarifa !== 0
-                                      ? ((rate.tarifa - item.tarifa) / item.tarifa) * 100
-                                      : 0;
-                                  const sign = percentage > 0 ? "+" : "";
-                                  return `${sign}${percentage.toFixed(2)}%`;
-                                })()}
-                              </span>
-                            </td>
-                            <td className="px-4 py-3">
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => onRemoveComparisonRate(item.id, rate.id)}
-                                className="text-red-600 hover:text-red-700 hover:bg-red-50"
-                              >
-                                <X className="h-4 w-4" />
-                              </Button>
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => onOpenModalCarrierPricing(item.id)}
-                    className="mt-4 border-2 hover:bg-gray-50"
-                  >
-                    <Plus className="h-4 w-4 mr-2" />
-                    Agregar tarifa comparativa
-                  </Button>
-                </div>
-              )}
+              <div className="ml-4">
+                {expandedAnalysis[item.id] ? (
+                  <ChevronUp className="h-5 w-5 text-gray-500" />
+                ) : (
+                  <ChevronDown className="h-5 w-5 text-gray-500" />
+                )}
+              </div>
             </div>
-          ))}
-        </div>
-      )}
 
-      <div className="flex items-start space-x-3 p-4 bg-blue-50 rounded-lg border-2 border-blue-200">
-        <Controller
-          name="isSingleSource"
-          control={control}
-          render={({ field }) => (
-            <Checkbox
-              id="singleSource"
-              checked={field.value}
-              onCheckedChange={field.onChange}
-              className="mt-0.5 border-2 border-blue-600 data-[state=checked]:bg-blue-600 data-[state=checked]:text-white"
-            />
-          )}
-        />
-        <Label
-          htmlFor="singleSource"
-          className="text-sm text-gray-900 font-medium cursor-pointer leading-relaxed"
-        >
-          Enviar solicitud de aprobación como Single source
-        </Label>
+            {/* Comparison table for forecast items */}
+            {expandedAnalysis[item.id] && (
+              <div className="p-4 bg-white">
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead className="bg-gray-50 border-b border-gray-200">
+                      <tr>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                          Proveedor
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                          Tipo
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                          Tipo vehículo
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                          Tipo tarifa
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                          Contrato
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                          Tarifa
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700">
+                          Diferencia
+                        </th>
+                        <th className="px-4 py-3"></th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200">
+                      {(comparisonRates[item.id] || []).map((rate) => (
+                        <tr key={rate.id} className="hover:bg-gray-50">
+                          <td className="px-4 py-3">
+                            <span className="text-sm text-gray-900">{rate.proveedor || "-"}</span>
+                          </td>
+                          <td className="px-4 py-3">
+                            <span className="text-sm text-gray-900">{rate.tipo || "-"}</span>
+                          </td>
+                          <td className="px-4 py-3">
+                            <span className="text-sm text-gray-900">
+                              {rate.tipoVehiculo || "-"}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3">
+                            <span className="text-sm text-gray-900">{rate.tipoTarifa || "-"}</span>
+                          </td>
+                          <td className="px-4 py-3">
+                            <span className="text-sm text-gray-900">{rate.contrato || "-"}</span>
+                          </td>
+                          <td className="px-4 py-3">
+                            <span className="text-sm font-medium text-gray-900">
+                              $ {rate.tarifa.toLocaleString("es-CO")}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3">
+                            <span
+                              className={`text-sm font-medium ${
+                                rate.diferencia > 0
+                                  ? "text-red-600"
+                                  : rate.diferencia < 0
+                                    ? "text-green-600"
+                                    : "text-gray-900"
+                              }`}
+                            >
+                              {(() => {
+                                // Calculate percentage difference, protecting against division by zero
+                                const percentage =
+                                  item.tarifa !== 0
+                                    ? ((rate.tarifa - item.tarifa) / item.tarifa) * 100
+                                    : 0;
+                                const sign = percentage > 0 ? "+" : "";
+                                return `${sign}${percentage.toFixed(2)}%`;
+                              })()}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => onRemoveComparisonRate(item.id, rate.id)}
+                              className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                            >
+                              <X className="h-4 w-4" />
+                            </Button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onOpenModalCarrierPricing(item.id)}
+                  className="mt-4 border-2 hover:bg-gray-50"
+                >
+                  <Plus className="h-4 w-4 mr-2" />
+                  Agregar tarifa comparativa
+                </Button>
+              </div>
+            )}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/modules/logistics/approval/components/NewApprovalForm/newApprovalForm.tsx
+++ b/src/modules/logistics/approval/components/NewApprovalForm/newApprovalForm.tsx
@@ -128,7 +128,6 @@ export function NewApprovalForm() {
   const tipoAprobacion = watch("tipoAprobacion");
   const forecastItems = watch("forecastItems");
   const comparisonRates = watch("comparisonRates");
-  const isSingleSource = watch("isSingleSource");
   const approvers = watch("approvers");
 
   // Helper: Update cantidad de usos for forecast items
@@ -212,7 +211,7 @@ export function NewApprovalForm() {
       id_approval_type: approvalType.id,
       pricings,
       approvers: approversData,
-      send_single_source: data.isSingleSource,
+      send_single_source: false,
       is_another_contract_active: data.validadoCoordinador === "si",
       is_provider_recommended_by_sustainability: data.proveedorRecomendado === "si",
       tercerization_motive: data.motivoTercerizacion || "",
@@ -516,11 +515,11 @@ export function NewApprovalForm() {
         <ComparativeAnalysis
           forecastItems={forecastItems}
           comparisonRates={comparisonRates}
-          isSingleSource={isSingleSource}
           control={control}
           onRemoveComparisonRate={removeComparisonRate}
           onOpenModalCarrierPricing={handleOpenModalCarrierPricing}
           calculateGrandTotal={calculateGrandTotal}
+          tipoAprobacion={tipoAprobacion}
         />
 
         {/* Observaciones section */}

--- a/src/modules/logistics/approval/components/ValidationQuestions/OutsourcingQuestions.tsx
+++ b/src/modules/logistics/approval/components/ValidationQuestions/OutsourcingQuestions.tsx
@@ -57,7 +57,7 @@ export function OutsourcingQuestions({ control, watch, setValue }: OutsourcingQu
 
       <div className="space-y-3">
         <Label className="text-sm font-medium text-gray-700">
-          Existen proveedores en la zona para prestar el servicio
+          ¿Existen proveedores en la zona para prestar el servicio?
         </Label>
         <Controller
           name="existenProveedoresZona"

--- a/src/modules/logistics/approval/components/ValidationQuestions/RecurringRateQuestions.tsx
+++ b/src/modules/logistics/approval/components/ValidationQuestions/RecurringRateQuestions.tsx
@@ -31,8 +31,8 @@ export function RecurringRateQuestions({
     <>
       <div className="space-y-3">
         <Label className="text-sm font-medium text-gray-700">
-          Valido previamente con el coordinador de la zona que no haya un contrato activo para
-          este scope?
+          ¿Validó previamente con el coordinador de la zona que no haya un contrato activo para este
+          scope?
         </Label>
         <Controller
           name="validadoCoordinador"

--- a/src/modules/logistics/approval/components/ValidationQuestions/SpecificTripQuestions.tsx
+++ b/src/modules/logistics/approval/components/ValidationQuestions/SpecificTripQuestions.tsx
@@ -31,8 +31,8 @@ export function SpecificTripQuestions({
     <>
       <div className="space-y-3">
         <Label className="text-sm font-medium text-gray-700">
-          Valido previamente con el coordinador de la zona que no haya un contrato activo para
-          este scope?
+          ¿Validó previamente con el coordinador de la zona que no haya un contrato activo para este
+          scope?
         </Label>
         <Controller
           name="validadoCoordinador"
@@ -75,7 +75,11 @@ export function SpecificTripQuestions({
             <RadioGroup value={field.value} onValueChange={field.onChange} required>
               <div className="flex items-center space-x-6">
                 <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="si" id={`recomendado-si-${idPrefix}`} className="border-2" />
+                  <RadioGroupItem
+                    value="si"
+                    id={`recomendado-si-${idPrefix}`}
+                    className="border-2"
+                  />
                   <Label
                     htmlFor={`recomendado-si-${idPrefix}`}
                     className="font-normal cursor-pointer text-gray-700"
@@ -84,7 +88,11 @@ export function SpecificTripQuestions({
                   </Label>
                 </div>
                 <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="no" id={`recomendado-no-${idPrefix}`} className="border-2" />
+                  <RadioGroupItem
+                    value="no"
+                    id={`recomendado-no-${idPrefix}`}
+                    className="border-2"
+                  />
                   <Label
                     htmlFor={`recomendado-no-${idPrefix}`}
                     className="font-normal cursor-pointer text-gray-700"

--- a/src/types/logistics/approval.ts
+++ b/src/types/logistics/approval.ts
@@ -39,7 +39,6 @@ export interface INewApprovalForm {
   // General fields
   tipoAprobacion: string;
   observaciones: string;
-  isSingleSource: boolean;
 
   // Specific Trip / Recurring Rate questions
   validadoCoordinador: string;
@@ -65,7 +64,6 @@ export const defaultApprovalFormValues: INewApprovalForm = {
   // General
   tipoAprobacion: "",
   observaciones: "",
-  isSingleSource: false,
 
   // Specific Trip / Recurring Rate
   validadoCoordinador: "",


### PR DESCRIPTION
This pull request refactors the approval form logic by removing the `isSingleSource` field and related UI, and instead relies solely on the `tipoAprobacion` field to determine when to show the comparative analysis. It also includes minor improvements to question phrasing for clarity.

**Approval Form Refactor:**

* Removed the `isSingleSource` field from the `INewApprovalForm` type, default values, and all related UI in `ComparativeAnalysis` and `NewApprovalForm`. The comparative analysis section is now conditionally rendered based on `tipoAprobacion === "tarifa-recurrente"` instead of `isSingleSource`. [[1]](diffhunk://#diff-2aec7b769c0d97f78426afd3ee27a9db1d26173b141d8671ef89bedbff3890eeL14-R28) [[2]](diffhunk://#diff-2aec7b769c0d97f78426afd3ee27a9db1d26173b141d8671ef89bedbff3890eeL50) [[3]](diffhunk://#diff-2aec7b769c0d97f78426afd3ee27a9db1d26173b141d8671ef89bedbff3890eeL195-L216) [[4]](diffhunk://#diff-ecb16e4a032eec371c6012e8a88ee0357b38390245f83ac261aa12d7d7040582L131) [[5]](diffhunk://#diff-ecb16e4a032eec371c6012e8a88ee0357b38390245f83ac261aa12d7d7040582L215-R214) [[6]](diffhunk://#diff-ecb16e4a032eec371c6012e8a88ee0357b38390245f83ac261aa12d7d7040582L519-R522) [[7]](diffhunk://#diff-b9d5604d9fae415ecd41eaf2bb8cf57afe4552417dfca92ce7145b258d2162cbL42) [[8]](diffhunk://#diff-b9d5604d9fae415ecd41eaf2bb8cf57afe4552417dfca92ce7145b258d2162cbL68)

**UI and Wording Improvements:**

* Updated question labels in validation components to use proper Spanish phrasing and punctuation for clarity (e.g., "¿Validó previamente con el coordinador de la zona...?"). [[1]](diffhunk://#diff-e56d01ec5a1f3336213272ab1640104a970855243625864c29c618861610a6bcL60-R60) [[2]](diffhunk://#diff-d3b901be060056eb041315566d175f9ecabf8283c329e4ac03813ef04ce8c3baL34-R35) [[3]](diffhunk://#diff-35e2f95fb16b4020ae6f5fabd074e8501132d9690f9f3bc32dc6cef04cbe89d4L34-R35)
* Minor formatting adjustments for radio button groups in `SpecificTripQuestions` for better readability. [[1]](diffhunk://#diff-35e2f95fb16b4020ae6f5fabd074e8501132d9690f9f3bc32dc6cef04cbe89d4L78-R82) [[2]](diffhunk://#diff-35e2f95fb16b4020ae6f5fabd074e8501132d9690f9f3bc32dc6cef04cbe89d4L87-R95)