### PR TITLE
Feat/add responsive2 side bar

### DIFF
--- a/src/components/atoms/NavigationBar/ModulesButtons/ModulesButtons.tsx
+++ b/src/components/atoms/NavigationBar/ModulesButtons/ModulesButtons.tsx
@@ -14,8 +14,13 @@ import {
   Receipt,
   ClipboardText
 } from "phosphor-react";
+
 import { checkUserViewPermissions } from "@/utils/utils";
 import { ISelectedProject } from "@/lib/slices/createProjectSlice";
+
+import useScreenHeight from "@/components/hooks/useScreenHeight";
+import useScreenWidth from "@/components/hooks/useScreenWidth";
+
 import "./modulesButtons.scss";
 
 interface ModulesButtonsProps {
@@ -35,6 +40,10 @@ export const ModulesButtons = ({
   project,
   isMobileMenu
 }: ModulesButtonsProps) => {
+  const height = useScreenHeight();
+  const width = useScreenWidth();
+  const iconSize = (height && height >= 1000) || (width && width > 768) ? 26 : 18;
+
   return (
     <div className={`containerButtons ${isMobileMenu ? "mobile" : ""}`}>
       {checkUserViewPermissions(project, "Clientes") && (
@@ -42,7 +51,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<User size={26} />}
+            icon={<User size={iconSize} />}
             className={path.startsWith("/clientes") ? "buttonIcon" : "buttonIconActive"}
           >
             {isSideBarLarge && "Clientes"}
@@ -54,7 +63,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<BellSimpleRinging size={26} />}
+            icon={<BellSimpleRinging size={iconSize} />}
             className={path.startsWith("/descuentos") ? "buttonIcon" : "buttonIconActive"}
           >
             {isSideBarLarge && "Descuentos"}
@@ -66,7 +75,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<BellSimpleRinging size={26} />}
+            icon={<BellSimpleRinging size={iconSize} />}
             className={path.startsWith("/notificaciones") ? "buttonIcon" : "buttonIconActive"}
           >
             {isSideBarLarge && "Notificaciones"}
@@ -79,7 +88,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<Megaphone size={26} />}
+            icon={<Megaphone size={iconSize} />}
             className={path.startsWith("/comercio") ? "buttonIcon" : "buttonIconActive"}
           >
             {isSideBarLarge && "Descuentos"}
@@ -92,7 +101,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<Bank size={26} />}
+            icon={<Bank size={iconSize} />}
             className={path === "/banco" ? "buttonIcon" : "buttonIconActive"}
           >
             {isSideBarLarge && "Bancos"}
@@ -105,7 +114,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<TrendUp size={26} />}
+            icon={<TrendUp size={iconSize} />}
             className={path.startsWith("/logistics/contracts") ? "buttonIcon" : "buttonIconActive"}
           >
             {isSideBarLarge && "Ajustes"}
@@ -117,7 +126,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<Gear size={26} />}
+            icon={<Gear size={iconSize} />}
             className={
               path === "/" || path.startsWith("/proyectos/review")
                 ? "buttonIcon"
@@ -133,7 +142,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<UsersThree size={26} />}
+            icon={<UsersThree size={iconSize} />}
             className={path.startsWith("/logistics/providers") ? "buttonIcon" : "buttonIconActive"}
           >
             {isSideBarLarge && "Clientes"}
@@ -145,7 +154,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<MapPin size={26} />}
+            icon={<MapPin size={iconSize} />}
             className={path.startsWith("/map") ? "buttonIcon" : "buttonIconActive"}
           >
             {isSideBarLarge && "Ajustes"}
@@ -157,7 +166,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<Truck size={26} />}
+            icon={<Truck size={iconSize} />}
             className={
               path.startsWith("/logistics/transfer-orders") || path.startsWith("/logistics/orders")
                 ? "buttonIcon"
@@ -173,7 +182,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<CurrencyCircleDollar size={26} />}
+            icon={<CurrencyCircleDollar size={iconSize} />}
             className={
               path.startsWith("/logistics/acept_carrier") ? "buttonIcon" : "buttonIconActive"
             }
@@ -187,7 +196,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<Receipt size={26} />}
+            icon={<Receipt size={iconSize} />}
             className={path.startsWith("/facturacion") ? "buttonIcon" : "buttonIconActive"}
           >
             {isSideBarLarge && "Proveedores"}
@@ -199,7 +208,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<Gear size={26} />}
+            icon={<Gear size={iconSize} />}
             className={
               path.startsWith("/logistics/configuration") ? "buttonIcon" : "buttonIconActive"
             }
@@ -213,7 +222,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<ClipboardText size={26} />}
+            icon={<ClipboardText size={iconSize} />}
             className={path === "/gestor-tareas" ? "buttonIcon" : "buttonIconActive"}
           >
             {isSideBarLarge && "Tareas"}
@@ -225,7 +234,7 @@ export const ModulesButtons = ({
           <Button
             type="primary"
             size="large"
-            icon={<ChatCircleDots size={26} />}
+            icon={<ChatCircleDots size={iconSize} />}
             className={path === "/chat" ? "buttonIcon" : "buttonIconActive"}
           >
             {isSideBarLarge && "Ajustes"}

--- a/src/components/atoms/NavigationBar/ModulesButtons/modulesButtons.scss
+++ b/src/components/atoms/NavigationBar/ModulesButtons/modulesButtons.scss
@@ -35,3 +35,9 @@
         }
     }
 }
+
+@media (max-width: 768px) {
+    .containerButtons {
+        padding: 7px 16px;
+    }
+}

--- a/src/components/molecules/SideBar/SideBar.tsx
+++ b/src/components/molecules/SideBar/SideBar.tsx
@@ -14,10 +14,13 @@ import { ModalProjectSelector } from "../modals/ModalProjectSelector/ModalProjec
 import { setProjectInApi } from "@/utils/api/api";
 import { ModulesButtons } from "@/components/atoms/NavigationBar/ModulesButtons/ModulesButtons";
 import useScreenWidth from "@/components/hooks/useScreenWidth";
+import useScreenHeight from "@/components/hooks/useScreenHeight";
 
 export const SideBar = () => {
   const [isSideBarLarge, setIsSideBarLarge] = useState(false);
   const width = useScreenWidth();
+  const height = useScreenHeight();
+  const iconSize = (height && height >= 1000) || (width && width > 768) ? 26 : 18;
   const [modalProjectSelectorOpen, setModalProjectSelectorOpen] = useState(false);
   const [isComponentLoading, setIsComponentLoading] = useState(true);
   const [isModuleMenuOpen, setIsModuleMenuOpen] = useState(false);
@@ -108,7 +111,7 @@ export const SideBar = () => {
     <div className={`sidebar ${isSideBarLarge ? "mainLarge" : "main"}`}>
       {width && width <= 768 ? (
         <Button type="text" className="buttonMenu" onClick={handleButtonMenuClick}>
-          <List size={26} />
+          <List size={iconSize} />
         </Button>
       ) : null}
       {isModuleMenuOpen && width && width <= 768 ? (
@@ -134,17 +137,14 @@ export const SideBar = () => {
           <ModulesButtons isSideBarLarge={isSideBarLarge} path={path} project={project} />
         ) : null}
       </Flex>
-      <Flex className="exit">
-        <Button
-          type="text"
-          size="large"
-          onClick={() => logOut(router)}
-          icon={<ArrowLineRight size={26} />}
-          className="buttonExit"
-        >
-          {isSideBarLarge && "Salir"}
-        </Button>
-      </Flex>
+      <Button
+        type="text"
+        onClick={() => logOut(router)}
+        icon={<ArrowLineRight size={iconSize} />}
+        className="buttonExit"
+      >
+        {isSideBarLarge && "Salir"}
+      </Button>
       <ModalProjectSelector
         isOpen={modalProjectSelectorOpen}
         onClose={() => setModalProjectSelectorOpen(false)}

--- a/src/components/molecules/SideBar/sidebar.scss
+++ b/src/components/molecules/SideBar/sidebar.scss
@@ -57,45 +57,6 @@
     padding-top: 5rem;
     position: relative;
     box-shadow: 7px 1px 5px 2px #f0f0f0;
-
-    .containerButtons {
-        display: flex;
-        width: 90%;
-        padding: 10px 14px;
-        align-items: center;
-        row-gap: 6px;
-        .logoContainer {
-            margin-bottom: 2rem;
-        }
-
-        .buttonIcon {
-            background-color: $secondary;
-            box-shadow: none;
-            display: flex;
-            width: 100%;
-            color: black;
-            align-items: center;
-
-            &:hover {
-                background-color: $secondary !important;
-                color: black;
-            }
-        }
-
-        .buttonIconActive {
-            width: 100%;
-            background-color: transparent;
-            color: black;
-            box-shadow: none;
-            display: flex;
-            align-items: center;
-
-            &:hover {
-                background-color: $secondary !important;
-                color: black;
-            }
-        }
-    }
 }
 
 // Mobile menu wrapper styles
@@ -139,40 +100,6 @@
 
         .logoContainer {
             margin: 0;
-        }
-
-        // Mobile menu specific styles when inside sidebar
-        .mobileMenuWrapper {
-            .containerButtons {
-                flex-direction: row;
-                gap: 10px;
-                overflow-x: auto;
-                overflow-y: hidden;
-                padding: 16px 14px;
-
-                // Hide scrollbar for better appearance
-                &::-webkit-scrollbar {
-                    height: 4px;
-                }
-
-                &::-webkit-scrollbar-track {
-                    background: transparent;
-                }
-
-                &::-webkit-scrollbar-thumb {
-                    background: rgba(0, 0, 0, 0.2);
-                    border-radius: 4px;
-                }
-
-                &::-webkit-scrollbar-thumb:hover {
-                    background: rgba(0, 0, 0, 0.3);
-                }
-
-                .buttonIcon,
-                .buttonIconActive {
-                    flex-shrink: 0;
-                }
-            }
         }
     }
 }

--- a/src/components/molecules/SideBar/sidebar.scss
+++ b/src/components/molecules/SideBar/sidebar.scss
@@ -37,8 +37,8 @@
         }
     }
 
-    .buttonMenu {
-        border-radius: 50%;
+    .buttonMenu,
+    .buttonExit {
         aspect-ratio: 1 / 1 !important;
         padding: 12px 6px;
     }
@@ -96,15 +96,6 @@
             }
         }
     }
-    .exit {
-        display: flex;
-        .buttonExit {
-            display: flex;
-            align-items: center;
-            box-shadow: none;
-            justify-content: center;
-        }
-    }
 }
 
 // Mobile menu wrapper styles
@@ -140,8 +131,7 @@
         height: auto;
         flex-direction: row;
         flex-wrap: wrap;
-        padding: 1rem;
-        padding-left: 2rem;
+        padding: 1rem 2rem;
         align-items: center;
         border-radius: 0 0 1rem 1rem;
         box-shadow: 0px 5px 16px -3px #f0f0f0;
@@ -183,6 +173,25 @@
                     flex-shrink: 0;
                 }
             }
+        }
+    }
+}
+
+@media (max-height: 1000px) and (max-width: 768px) {
+    .main {
+        max-height: 42px;
+        padding: 6px 16px;
+        align-content: center;
+        .logoContainer {
+            &__image {
+                width: 25px;
+                height: 25px;
+            }
+        }
+
+        .buttonMenu,
+        .buttonExit {
+            padding: 4px 2px;
         }
     }
 }


### PR DESCRIPTION
<img width="746" height="931" alt="image" src="https://github.com/user-attachments/assets/984b2ce3-9b23-41d5-bcb2-1b4065e0ea34" />
<img width="562" height="897" alt="image" src="https://github.com/user-attachments/assets/17edbc5a-1808-445a-af8d-5758a72c7341" />
This pull request improves the responsiveness of the navigation and sidebar components by dynamically adjusting icon sizes based on screen dimensions and refining related styles for better mobile usability. The main changes involve updating how icon sizes are set in both `ModulesButtons` and `SideBar`, and reorganizing SCSS for cleaner, more maintainable styling.

**Responsive icon sizing and usage:**

* Updated `ModulesButtons.tsx` and `SideBar.tsx` to use `useScreenHeight` and `useScreenWidth` hooks, setting icon sizes to either 26 or 18 depending on screen height and width, making the UI more adaptive to different devices. [[1]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fR17-R23) [[2]](diffhunk://#diff-c5f8aea9a65ea573dbf41b76a06b7b5e9be2b9b0f1f5cfc8698c7d2394d348f7R17-R23)
* Replaced all hardcoded icon sizes in button components with the new dynamic `iconSize` value for consistent scaling across navigation modules and sidebar actions. [[1]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fR43-R54) [[2]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL57-R66) [[3]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL69-R78) [[4]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL82-R91) [[5]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL95-R104) [[6]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL108-R117) [[7]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL120-R129) [[8]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL136-R145) [[9]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL148-R157) [[10]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL160-R169) [[11]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL176-R185) [[12]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL190-R199) [[13]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL202-R211) [[14]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL216-R225) [[15]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL228-R237) [[16]](diffhunk://#diff-c5f8aea9a65ea573dbf41b76a06b7b5e9be2b9b0f1f5cfc8698c7d2394d348f7L111-R114) [[17]](diffhunk://#diff-c5f8aea9a65ea573dbf41b76a06b7b5e9be2b9b0f1f5cfc8698c7d2394d348f7L137-L147)

**SCSS reorganization and mobile style improvements:**

* Refactored sidebar and navigation button SCSS, removing redundant nested styles and consolidating button styling for easier maintenance. [[1]](diffhunk://#diff-b11753a507fb8936c2fb956014ac49b54989e6e5a34327ae8726594a25d6a15cL60-L107) [[2]](diffhunk://#diff-b11753a507fb8936c2fb956014ac49b54989e6e5a34327ae8726594a25d6a15cL143-R95) [[3]](diffhunk://#diff-b11753a507fb8936c2fb956014ac49b54989e6e5a34327ae8726594a25d6a15cL153-R121)
* Improved mobile-specific styles for `.containerButtons` and sidebar layout, including padding adjustments and icon/button sizing for smaller screens. [[1]](diffhunk://#diff-4403ae2248bc2366019f1e242c52825bde713967a9c75b3c576a719d06a2fc3cR38-R43) [[2]](diffhunk://#diff-b11753a507fb8936c2fb956014ac49b54989e6e5a34327ae8726594a25d6a15cL143-R95) [[3]](diffhunk://#diff-b11753a507fb8936c2fb956014ac49b54989e6e5a34327ae8726594a25d6a15cL153-R121)

These updates ensure that navigation elements look and behave consistently across devices, improving the overall user experience and maintainability of the codebase.