### PR TITLE
Feat/add percentage comparation based on average sum prices

### DIFF
--- a/src/modules/logistics/approval/components/ComparativeAnalysis/ComparativeAnalysis.tsx
+++ b/src/modules/logistics/approval/components/ComparativeAnalysis/ComparativeAnalysis.tsx
@@ -37,7 +37,34 @@ export function ComparativeAnalysis({
     });
   };
 
-  console.log("tipoAprobacion: string", tipoAprobacion);
+  // Calculate balance percentage: difference between main rate and average of comparison rates
+  const calculateBalancePercentage = (item: ForecastItem) => {
+    const itemComparisonRates = comparisonRates[item.id] || [];
+
+    // Don't show balance if there are no comparison rates
+    if (itemComparisonRates.length === 0) {
+      return null;
+    }
+
+    // Calculate average of comparison rates
+    const sumOfComparisonRates = itemComparisonRates.reduce((sum, rate) => sum + rate.tarifa, 0);
+    const average = sumOfComparisonRates / itemComparisonRates.length;
+
+    // Protect against division by zero
+    if (average === 0) {
+      return null;
+    }
+
+    // Calculate percentage difference: ((mainRate - average) / average) * 100
+    const difference = item.tarifa - average;
+    const percentage = (difference / average) * 100;
+
+    return {
+      percentage: percentage.toFixed(2),
+      isPositive: percentage > 0,
+      formattedPercentage: `${percentage > 0 ? "+" : ""}${percentage.toFixed(1)}%`
+    };
+  };
 
   if (tipoAprobacion !== "tarifa-recurrente") {
     return null;
@@ -64,12 +91,29 @@ export function ComparativeAnalysis({
               <div className="flex-1">
                 <div className="flex items-center justify-between">
                   <h3 className="font-semibold text-gray-900">{item.proveedor}</h3>
-                  <div className="text-right">
-                    <div className="text-lg font-bold text-gray-900">
-                      $ {item.tarifa.toLocaleString("es-CO")}
-                    </div>
-                    <div className="text-sm text-gray-600">
-                      {item.tipoVehiculo} • Km {item.descripcionTarifa}
+                  <div className="flex items-start gap-2">
+                    {/* General balance: percentage difference between main rate and average of comparison rates */}
+                    {(() => {
+                      const balance = calculateBalancePercentage(item);
+                      if (!balance) return null;
+
+                      return (
+                        <div
+                          className={`text-lg font-semibold ${
+                            balance.isPositive ? "text-red-600" : "text-green-600"
+                          }`}
+                        >
+                          {balance.formattedPercentage}
+                        </div>
+                      );
+                    })()}
+                    <div className="text-right">
+                      <div className="text-lg font-bold text-gray-900">
+                        $ {item.tarifa.toLocaleString("es-CO")}
+                      </div>
+                      <div className="text-sm text-gray-600">
+                        {item.tipoVehiculo} • Km {item.descripcionTarifa}
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -143,15 +187,7 @@ export function ComparativeAnalysis({
                             </span>
                           </td>
                           <td className="px-4 py-3">
-                            <span
-                              className={`text-sm font-medium ${
-                                rate.diferencia > 0
-                                  ? "text-red-600"
-                                  : rate.diferencia < 0
-                                    ? "text-green-600"
-                                    : "text-gray-900"
-                              }`}
-                            >
+                            <span className={`text-sm font-medium text-gray-900`}>
                               {(() => {
                                 // Calculate percentage difference, protecting against division by zero
                                 const percentage =


### PR DESCRIPTION
<img width="1238" height="916" alt="image" src="https://github.com/user-attachments/assets/af703636-dde7-42a6-9752-c3dec1281383" />
This pull request enhances the `ComparativeAnalysis` component by introducing a new feature that calculates and displays the percentage difference between the main rate and the average of comparison rates for each item. It also improves the UI by color-coding the balance indicator for better clarity, while simplifying the styling of individual rate differences.

### New Feature: Comparative Balance Calculation

* Added a `calculateBalancePercentage` helper function to compute the percentage difference between the main rate and the average of comparison rates for each `ForecastItem`. This function handles edge cases such as missing comparison rates and division by zero.
* Displayed the calculated balance percentage next to each vendor's name, with conditional color coding: red for positive (main rate higher than average) and green for negative (main rate lower than average).

### UI Improvements

* Updated the layout to accommodate the new balance indicator alongside vendor information.
* Simplified the styling of individual rate differences in the comparison table, removing conditional color coding and using a neutral color for consistency.