### PR TITLE
Refactor ComparativeAnalysis component by removing unused props and c…

### DIFF
--- a/src/modules/logistics/approval/components/ComparativeAnalysis/ComparativeAnalysis.tsx
+++ b/src/modules/logistics/approval/components/ComparativeAnalysis/ComparativeAnalysis.tsx
@@ -1,31 +1,24 @@
 "use client";
 
 import { useState } from "react";
-import { Controller, Control } from "react-hook-form";
 import { Plus, X, ChevronDown, ChevronUp } from "lucide-react";
-import { Label } from "@/modules/chat/ui/label";
 import { Button } from "@/modules/chat/ui/button";
-import { Checkbox } from "@/modules/chat/ui/checkbox";
-import type { INewApprovalForm, ForecastItem, ComparisonRate } from "@/types/logistics/approval";
+import type { ForecastItem, ComparisonRate } from "@/types/logistics/approval";
 
 interface ComparativeAnalysisProps {
   forecastItems: ForecastItem[];
   comparisonRates: Record<string, ComparisonRate[]>;
-  control: Control<INewApprovalForm>;
   onRemoveComparisonRate: (forecastItemId: string, rateId: string) => void;
   onOpenModalCarrierPricing: (forecastItemId: string) => void;
   calculateGrandTotal: () => number;
-  tipoAprobacion: string;
 }
 
 export function ComparativeAnalysis({
   forecastItems,
   comparisonRates,
-  control,
   onRemoveComparisonRate,
   onOpenModalCarrierPricing,
-  calculateGrandTotal,
-  tipoAprobacion
+  calculateGrandTotal
 }: ComparativeAnalysisProps) {
   // Local state for expanded accordion items
   const [expandedAnalysis, setExpandedAnalysis] = useState<Record<string, boolean>>({});
@@ -65,10 +58,6 @@ export function ComparativeAnalysis({
       formattedPercentage: `${percentage > 0 ? "+" : ""}${percentage.toFixed(1)}%`
     };
   };
-
-  if (tipoAprobacion !== "tarifa-recurrente") {
-    return null;
-  }
 
   return (
     <div className="mb-8 pb-8 border-t border-gray-200 pt-8">

--- a/src/modules/logistics/approval/components/NewApprovalForm/newApprovalForm.tsx
+++ b/src/modules/logistics/approval/components/NewApprovalForm/newApprovalForm.tsx
@@ -535,11 +535,9 @@ export function NewApprovalForm() {
         <ComparativeAnalysis
           forecastItems={forecastItems}
           comparisonRates={comparisonRates}
-          control={control}
           onRemoveComparisonRate={removeComparisonRate}
           onOpenModalCarrierPricing={handleOpenModalCarrierPricing}
           calculateGrandTotal={calculateGrandTotal}
-          tipoAprobacion={tipoAprobacion}
         />
 
         {/* Observaciones section */}


### PR DESCRIPTION
…onditional rendering
This pull request simplifies the `ComparativeAnalysis` component by removing unused props and related conditional logic, making the component interface cleaner and easier to maintain. The changes also update its usage in the `NewApprovalForm` to match the new prop signature.

**Component interface simplification:**

* Removed the unused `control` and `tipoAprobacion` props from the `ComparativeAnalysis` component and its usage in `NewApprovalForm`, streamlining the component's interface. [[1]](diffhunk://#diff-2aec7b769c0d97f78426afd3ee27a9db1d26173b141d8671ef89bedbff3890eeL4-R21) [[2]](diffhunk://#diff-ecb16e4a032eec371c6012e8a88ee0357b38390245f83ac261aa12d7d7040582L538-L542)
* Eliminated the conditional rendering logic based on `tipoAprobacion` from inside the `ComparativeAnalysis` component, ensuring the component always renders when included.