### PR TITLE
Feat/add permission chat route

### DIFF
--- a/src/components/atoms/NavigationBar/ModulesButtons/ModulesButtons.tsx
+++ b/src/components/atoms/NavigationBar/ModulesButtons/ModulesButtons.tsx
@@ -22,6 +22,7 @@ import useScreenHeight from "@/components/hooks/useScreenHeight";
 import useScreenWidth from "@/components/hooks/useScreenWidth";
 
 import "./modulesButtons.scss";
+import { ChatCircleDots } from "@phosphor-icons/react";
 
 interface ModulesButtonsProps {
   isSideBarLarge: boolean;
@@ -229,7 +230,7 @@ export const ModulesButtons = ({
           </Button>
         </Link>
       )}
-      {/* {true && (
+      {checkUserViewPermissions(project, "TMS-Whatsapp") && (
         <Link href="/chat" passHref legacyBehavior>
           <Button
             type="primary"
@@ -240,7 +241,7 @@ export const ModulesButtons = ({
             {isSideBarLarge && "Ajustes"}
           </Button>
         </Link>
-      )} */}
+      )}
     </div>
   );
 };

--- a/src/components/organisms/TaskManager/TaskManagerDetailView/index.tsx
+++ b/src/components/organisms/TaskManager/TaskManagerDetailView/index.tsx
@@ -89,7 +89,7 @@ const TaskManagerDetailView = ({ moduleTitle, approvalId, onBack }: TaskManagerD
       setShowApproveModal(false);
       const response = await updatePricingApprovalStatus(approvalId, "APPROVED");
       if (response.success) {
-        message.success(response.message);
+        message.success("La solicitud ha sido aprobada correctamente.");
         const detail = await getTaskDetail(approvalId);
         if (detail.success && detail.data) setTaskDetail(detail.data);
       } else {
@@ -111,7 +111,7 @@ const TaskManagerDetailView = ({ moduleTitle, approvalId, onBack }: TaskManagerD
       setShowRejectModal(false);
       const response = await updatePricingApprovalStatus(approvalId, "REJECTED");
       if (response.success) {
-        message.success(response.message);
+        message.success("La solicitud ha sido rechazada correctamente.");
         const detail = await getTaskDetail(approvalId);
         if (detail.success && detail.data) setTaskDetail(detail.data);
       } else {


### PR DESCRIPTION
This pull request introduces a new button for the chat module in the navigation bar, making it visible only to users with the correct permissions, and improves user feedback messages in the task manager detail view by providing clearer, more descriptive notifications.

**Navigation Bar Enhancements:**

* Added a new chat module button with the `ChatCircleDots` icon, which is conditionally rendered based on user permissions using `checkUserViewPermissions` for "TMS-Whatsapp". [[1]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fR25) [[2]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL232-R233) [[3]](diffhunk://#diff-e63dd7c270eef959f1c27045c09757885a17514631618cbbf0141120b8d3ee5fL243-R244)

**User Feedback Improvements:**

* Updated success messages in `TaskManagerDetailView` to use clearer, user-friendly text when approving ("La solicitud ha sido aprobada correctamente.") and rejecting ("La solicitud ha sido rechazada correctamente.") a request, instead of relying on generic backend messages. [[1]](diffhunk://#diff-45fc6b5a9e98b378e3844ff092ce411ac102c7b807458d14f3988a07a66c6323L92-R92) [[2]](diffhunk://#diff-45fc6b5a9e98b378e3844ff092ce411ac102c7b807458d14f3988a07a66c6323L114-R114)