### PR TITLE
Hotfix/Add url_evidence field to CarriersPricing and update NewApprovalForm …

### DIFF
--- a/src/modules/logistics/approval/components/NewApprovalForm/newApprovalForm.tsx
+++ b/src/modules/logistics/approval/components/NewApprovalForm/newApprovalForm.tsx
@@ -101,7 +101,7 @@ export function NewApprovalForm() {
             descripcionTarifa: carrier.service_type,
             tarifa: carrier.amount,
             cantidadUsos: 1,
-            cotizacionUrl: ""
+            cotizacionUrl: carrier.url_evidence
           }))
         : [];
 
@@ -442,7 +442,7 @@ export function NewApprovalForm() {
       link.download = `cotizacion_${proveedor.replace(/\s+/g, "_")}.pdf`;
       link.target = "_blank";
       link.click();
-      message.success(`Descargando cotización de ${proveedor}`);
+      message.success(`Descargada cotización de ${proveedor}`);
     } catch (error) {
       console.error("Error al descargar cotización:", error);
       message.error("Error al descargar la cotización");

--- a/src/types/logistics/schema.ts
+++ b/src/types/logistics/schema.ts
@@ -2090,6 +2090,7 @@ export interface CarriersPricing {
   volume: number;
   weight: number;
   observations: string | null;
+  url_evidence: string;
 }
 /**
  * Exposes all fields present in transfer_order as a typescript


### PR DESCRIPTION
…to use it
This pull request updates the approval form logic and carrier pricing schema to support evidence URLs for carrier quotations and improves user feedback messaging. The main changes focus on integrating a new field into the carrier pricing interface and ensuring the approval form uses this information when displaying and downloading carrier quotations.

**Schema and Data Integration:**

* Added a new `url_evidence` field to the `CarriersPricing` interface in `schema.ts` to store the URL for carrier quotation evidence.
* Updated the `NewApprovalForm` component to use the new `url_evidence` field for the `cotizacionUrl` property instead of a placeholder.

**User Experience Improvements:**

* Changed the success message after downloading a quotation in `NewApprovalForm` to indicate the file has been downloaded, improving clarity for users.