### PR TITLE
Feat/add expiration date in acept carrier

### DIFF
--- a/src/components/organisms/logistics/acept_carrier/detail/components/VehicleAndDriverAsignation/VehicleAndDriverAsignation.tsx
+++ b/src/components/organisms/logistics/acept_carrier/detail/components/VehicleAndDriverAsignation/VehicleAndDriverAsignation.tsx
@@ -159,18 +159,26 @@ const VehicleAndDriverAsignation = forwardRef(function VehicleAndDriverAsignatio
     setSelectedFiles(docsWithLink);
   }, [documentsTypes]);
 
-  // Función helper para obtener el status del vehículo seleccionado
-  const getVehicleStatus = () => {
+  // helper selected vehicle
+  const getSelectedVehicle = () => {
     if (!selectedVehicle || !vehicles) return null;
-    const vehicle = vehicles.find((v) => v.id === selectedVehicle);
-    return vehicle?.status;
+    return vehicles.find((v) => v.id === selectedVehicle);
   };
 
-  // Función helper para obtener el status del conductor seleccionado
-  const getDriverStatus = (driverId: number | null) => {
+  // helper selected vehicle status
+  const getVehicleStatus = () => {
+    return getSelectedVehicle()?.status;
+  };
+
+  // helper selected driver
+  const getSelectedDriver = (driverId: number | null) => {
     if (!driverId || !drivers) return null;
-    const driver = drivers.find((d) => d.id === driverId);
-    return driver?.status;
+    return drivers.find((d) => d.id === driverId);
+  };
+
+  // helper selected driver status
+  const getDriverStatus = (driverId: number | null) => {
+    return getSelectedDriver(driverId)?.status;
   };
 
   return (
@@ -239,7 +247,7 @@ const VehicleAndDriverAsignation = forwardRef(function VehicleAndDriverAsignatio
               )}
             </Flex>
 
-            {getVehicleStatus() && getVehicleStatus()?.id !== VALID_STATUS && (
+            {getVehicleStatus() && getVehicleStatus()?.id !== VALID_STATUS ? (
               <p>
                 El vehículo no se puede seleccionar para este viaje por documentación incompleta.{" "}
                 <Link
@@ -249,7 +257,22 @@ const VehicleAndDriverAsignation = forwardRef(function VehicleAndDriverAsignatio
                   Ir a corregir documentación.
                 </Link>
               </p>
-            )}
+            ) : null}
+
+            {getVehicleStatus() &&
+            getVehicleStatus()?.id === VALID_STATUS &&
+            getSelectedVehicle()?.documents_expiry ? (
+              <p>
+                El vehículo no se puede seleccionar para este viaje porque la documentación vence
+                antes del viaje.{" "}
+                <Link
+                  href={`/logistics/providers/${carrier?.id_carrier}/vehicle/${selectedVehicle}`}
+                  target="_blank"
+                >
+                  Ir a actualizar documentación.
+                </Link>
+              </p>
+            ) : null}
           </Flex>
         </div>
         {fields.map((field, indexField: number) => (
@@ -344,18 +367,33 @@ const VehicleAndDriverAsignation = forwardRef(function VehicleAndDriverAsignatio
                   </Flex>
 
                   {getDriverStatus(selectedDrivers[indexField]?.driverId) &&
-                    getDriverStatus(selectedDrivers[indexField]?.driverId)?.id !== VALID_STATUS && (
-                      <p>
-                        El conductor no se puede seleccionar para este viaje por documentación
-                        incompleta.{" "}
-                        <Link
-                          href={`/logistics/providers/${carrier?.id_carrier}/driver/${selectedDrivers[indexField]?.driverId}`}
-                          target="_blank"
-                        >
-                          Ir a corregir documentación.
-                        </Link>
-                      </p>
-                    )}
+                  getDriverStatus(selectedDrivers[indexField]?.driverId)?.id !== VALID_STATUS ? (
+                    <p>
+                      El conductor no se puede seleccionar para este viaje por documentación
+                      incompleta.{" "}
+                      <Link
+                        href={`/logistics/providers/${carrier?.id_carrier}/driver/${selectedDrivers[indexField]?.driverId}`}
+                        target="_blank"
+                      >
+                        Ir a corregir documentación.
+                      </Link>
+                    </p>
+                  ) : null}
+
+                  {getDriverStatus(selectedDrivers[indexField]?.driverId) &&
+                  getDriverStatus(selectedDrivers[indexField]?.driverId)?.id === VALID_STATUS &&
+                  getSelectedDriver(selectedDrivers[indexField]?.driverId)?.documents_expiry ? (
+                    <p>
+                      El conductor no se puede seleccionar para este viaje porque la documentación
+                      vence antes del viaje.{" "}
+                      <Link
+                        href={`/logistics/providers/${carrier?.id_carrier}/driver/${selectedDrivers[indexField]?.driverId}`}
+                        target="_blank"
+                      >
+                        Ir a actualizar documentación.
+                      </Link>
+                    </p>
+                  ) : null}
                 </Flex>
 
                 {indexField === fields.length - 1 && (

--- a/src/components/organisms/logistics/acept_carrier/view/AceptCarrierDetailView/AceptCarrierDetailView.tsx
+++ b/src/components/organisms/logistics/acept_carrier/view/AceptCarrierDetailView/AceptCarrierDetailView.tsx
@@ -67,8 +67,8 @@ export default function AceptCarrierDetailView({ params }: Readonly<AceptCarrier
   const [carrier, setCarrier] = useState<IAceptCarrierAPI>();
 
   // swr hooks used for revalidateOnFocus capability
-  const { vehicles: vehiclesData } = useVehicles(carrier?.id_carrier);
-  const { drivers: driversData } = useDrivers(carrier?.id_carrier);
+  const { vehicles: vehiclesData } = useVehicles(carrier?.id_carrier, carrier?.id_transfer_request);
+  const { drivers: driversData } = useDrivers(carrier?.id_carrier, carrier?.id_transfer_request);
 
   const [messageApi, contextHolder] = message.useMessage();
 

--- a/src/components/organisms/logistics/hooks/useDrivers.ts
+++ b/src/components/organisms/logistics/hooks/useDrivers.ts
@@ -1,10 +1,13 @@
 import { getDriverByCarrierId } from "@/services/logistics/acept_carrier";
 import useSWR from "swr";
 
-export const useDrivers = (carrierId: number | undefined) => {
+export const useDrivers = (
+  carrierId: number | undefined,
+  transferRequestId: number | undefined
+) => {
   const { data, error, isLoading, mutate } = useSWR(
-    carrierId ? `/driver/provider-active/${carrierId}` : null,
-    () => getDriverByCarrierId(carrierId || 0),
+    carrierId ? `/driver/provider-active/${carrierId}/${transferRequestId}` : null,
+    () => getDriverByCarrierId(carrierId || 0, transferRequestId || 0),
     {
       revalidateOnFocus: true,
       revalidateOnReconnect: true

--- a/src/components/organisms/logistics/hooks/useVehicles.ts
+++ b/src/components/organisms/logistics/hooks/useVehicles.ts
@@ -1,10 +1,13 @@
 import { getVehiclesByCarrierId } from "@/services/logistics/acept_carrier";
 import useSWR from "swr";
 
-export const useVehicles = (carrierId: number | undefined) => {
+export const useVehicles = (
+  carrierId: number | undefined,
+  transferRequestId: number | undefined
+) => {
   const { data, error, isLoading, mutate } = useSWR(
-    carrierId ? `/vehicle/provider-active/${carrierId}` : null,
-    () => getVehiclesByCarrierId(carrierId || 0),
+    carrierId ? `/vehicle/provider-active/${carrierId}/${transferRequestId}` : null,
+    () => getVehiclesByCarrierId(carrierId || 0, transferRequestId || 0),
     {
       revalidateOnFocus: true,
       revalidateOnReconnect: true

--- a/src/services/logistics/acept_carrier.ts
+++ b/src/services/logistics/acept_carrier.ts
@@ -47,11 +47,12 @@ export const getAceptCarrierRequestById = async (id: string): Promise<IAceptCarr
 };
 
 export const getVehiclesByCarrierId = async (
-  id: number
+  id: number,
+  transferRequestId: number
 ): Promise<GenericResponse<ICarrierRequestVehicles[]>> => {
   try {
     const response: GenericResponse<ICarrierRequestVehicles[]> = await API.get(
-      `/vehicle/provider-active/${id}`
+      `/vehicle/provider-active/${id}/${transferRequestId}`
     );
     return response;
   } catch (error) {
@@ -61,11 +62,12 @@ export const getVehiclesByCarrierId = async (
 };
 
 export const getDriverByCarrierId = async (
-  id: number
+  id: number,
+  transferRequestId: number
 ): Promise<GenericResponse<ICarrierRequestDrivers[]>> => {
   try {
     const response: GenericResponse<ICarrierRequestDrivers[]> = await API.get(
-      `/driver/provider-active/${id}`
+      `/driver/provider-active/${id}/${transferRequestId}`
     );
     return response;
   } catch (error) {

--- a/src/types/logistics/schema.ts
+++ b/src/types/logistics/schema.ts
@@ -568,6 +568,7 @@ export interface ICarrierRequestDrivers {
   rh: string;
   status: IStatusWithStyling;
   subject_id: number;
+  documents_expiry: boolean;
 }
 /**
  * Exposes all fields present in carrier_request_vehicles as a typescript
@@ -582,6 +583,7 @@ export interface ICarrierRequestVehicles {
   country: string;
   created_at: string;
   created_by: string;
+  documents_expiry: boolean;
   gps_link: string;
   gps_password: string;
   gps_user: string;


### PR DESCRIPTION
<img width="1234" height="937" alt="image" src="https://github.com/user-attachments/assets/942d1845-aef0-4256-af35-e89fa09ccfc9" />
This pull request enhances the vehicle and driver assignment logic to account for documentation expiry and improves the clarity and maintainability of related helper functions. It also updates the API calls and types to support these new checks by passing the transfer request ID and including documentation expiry information.

**Feature Enhancements:**

* Added checks in `VehicleAndDriverAsignation.tsx` to prevent selection of vehicles or drivers whose documentation expires before the trip, displaying appropriate messages and links for updating documentation. [[1]](diffhunk://#diff-619defe35ea5687fc9acb949c545d861ba3b0796d1ce2e36b77139abcbc4ab31L252-R275) [[2]](diffhunk://#diff-619defe35ea5687fc9acb949c545d861ba3b0796d1ce2e36b77139abcbc4ab31L358-R396)

**Refactoring and Code Quality:**

* Refactored helper functions in `VehicleAndDriverAsignation.tsx` for retrieving selected vehicles/drivers and their statuses, improving code readability and maintainability.

**API and Data Layer Updates:**

* Modified `useVehicles` and `useDrivers` hooks to accept and pass `transferRequestId`, ensuring API calls are specific to the transfer request context. [[1]](diffhunk://#diff-feb105f5292eda20c58739977bff776517774b2134cf5f0b37b6ac2ae71563deL70-R71) [[2]](diffhunk://#diff-b1d668c0a8bd2ddeedce04c13491ae1fb4bee1465f7b95881c1998f37345b5baL4-R10) [[3]](diffhunk://#diff-82f580d2a733df7326a99f511b329c074684d7a21dafe4c13dd6d3864a599f33L4-R10)
* Updated `getVehiclesByCarrierId` and `getDriverByCarrierId` service functions to accept and use `transferRequestId` in their API requests. [[1]](diffhunk://#diff-e56bf9fcbfa8599b3cf431223c4a2cffcabf7c3591b9bd19a2fa1e1d26e35465L50-R55) [[2]](diffhunk://#diff-e56bf9fcbfa8599b3cf431223c4a2cffcabf7c3591b9bd19a2fa1e1d26e35465L64-R70)

**Type Definitions:**

* Added `documents_expiry` boolean field to both `ICarrierRequestDrivers` and `ICarrierRequestVehicles` interfaces to support the new expiry checks. [[1]](diffhunk://#diff-90e65ea6f4b446b791d153c5d39adb4869ac11a0f49fdfe5e7ac67e0c1011b94R571) [[2]](diffhunk://#diff-90e65ea6f4b446b791d153c5d39adb4869ac11a0f49fdfe5e7ac67e0c1011b94R586)