### PR TITLE
Add ModalAddTR2TO component and integration for adding TO to ongoing TR

### DIFF
--- a/src/components/molecules/modals/ModalAddTR2TO/ModalAddTR2TO.tsx
+++ b/src/components/molecules/modals/ModalAddTR2TO/ModalAddTR2TO.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+import { Flex, message, Modal } from "antd";
+import { useForm } from "react-hook-form";
+
+import { addTOToOngoingTR } from "@/services/logistics/transfer-request";
+
+import FooterButtons from "@/components/atoms/FooterButtons/FooterButtons";
+import { InputForm } from "@/components/atoms/inputs/InputForm/InputForm";
+import { DataTypeForTransferOrderTable } from "../../tables/TransferOrderTable/TransferOrderTable";
+
+import "./modalAddTR2TO.scss";
+
+interface IFormModalAddTR2TO {
+  trId: string;
+}
+
+interface Props {
+  isOpen?: boolean;
+  onCancel: () => void;
+  onClose: () => void;
+  onSuccess?: () => void;
+  allSelectedRows?: DataTypeForTransferOrderTable[];
+}
+
+export const ModalAddTR2TO = ({ isOpen, onCancel, onClose, onSuccess, allSelectedRows }: Props) => {
+  const [loading, setLoading] = useState(false);
+
+  const {
+    handleSubmit,
+    formState: { errors, isValid },
+    reset,
+    control
+  } = useForm<IFormModalAddTR2TO>({});
+  //useEffect for fetching and cleaning the states when isOpen changes
+  useEffect(() => {
+    if (isOpen) {
+      reset();
+    }
+    return () => {
+      reset();
+    };
+  }, [isOpen]);
+
+  const onAddTO2TR = async (data: IFormModalAddTR2TO) => {
+    setLoading(true);
+
+    try {
+      // Extract TO ID and convert TR ID to number
+      const toId = allSelectedRows?.[0]?.key || 0;
+      const trId = parseInt(data.trId, 10);
+
+      if (isNaN(trId)) {
+        message.error("El ID de la TR debe ser un número válido");
+        setLoading(false);
+        return;
+      }
+
+      // Call API to add TO to TR
+      await addTOToOngoingTR(toId, trId);
+
+      message.success("TO añadida a la TR con éxito");
+      onClose();
+
+      // Call onSuccess callback if provided to refresh data
+      if (onSuccess) {
+        onSuccess();
+      }
+    } catch (error) {
+      message.error(`Error al añadir la TO a la TR: ${error}`);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <Modal
+      centered
+      className="ModalAddTR2TO"
+      width={"55%"}
+      open={isOpen}
+      footer={null}
+      closable={false}
+      destroyOnClose
+    >
+      <Flex gap={"1rem"} vertical style={{ width: "100%", height: "100%" }}>
+        <h4 className="ModalAddTR2TO__header">Añadir TO a TR en curso</h4>
+        <p>Escribe el ID de la TR a la que deseas añadir la orden de transferencia</p>
+
+        <InputForm
+          nameInput="trId"
+          titleInput="ID de la TR"
+          placeholder="Ejemplo: 12345"
+          typeInput="number"
+          control={control}
+          error={errors.trId}
+          validationRules={{
+            required: "El ID de la TR es obligatorio",
+            pattern: {
+              value: /^\d+$/,
+              message: "Debe ser un número válido"
+            }
+          }}
+        />
+
+        <FooterButtons
+          titleConfirm="Añadir TO a TR"
+          handleOk={handleSubmit(onAddTO2TR)}
+          onCancel={onCancel}
+          isConfirmLoading={loading}
+          isConfirmDisabled={!isValid}
+        />
+      </Flex>
+    </Modal>
+  );
+};

--- a/src/components/molecules/modals/ModalAddTR2TO/modalAddTR2TO.scss
+++ b/src/components/molecules/modals/ModalAddTR2TO/modalAddTR2TO.scss
@@ -1,0 +1,11 @@
+@import "@/styles/variables";
+
+.ModalAddTR2TO {
+    .ant-modal-content {
+        padding: 2rem !important;
+    }
+
+    &__header {
+        font-size: 1rem;
+    }
+}

--- a/src/components/molecules/modals/ModalGenerateActionOrders/ModalGenerateActionOrders.tsx
+++ b/src/components/molecules/modals/ModalGenerateActionOrders/ModalGenerateActionOrders.tsx
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Flex, message, Modal } from "antd";
 import { ArrowsClockwise, Download, LinkBreak, PauseCircle, Trash, X } from "phosphor-react";
-import { MinusCircle } from "@phosphor-icons/react";
+import { MinusCircle, Plus } from "@phosphor-icons/react";
 
 import {
   deleteOrders,
@@ -91,6 +91,13 @@ export default function ModalGenerateActionOrders(props: Readonly<PropsModalGene
     }
   };
 
+  const handleAddToOngoingTR = async () => {
+    if (allSelectedRows && allSelectedRows?.length > 1) {
+      return message.error("Solo puedes seleccionar una orden a la vez");
+    }
+    setIsModalOpen({ selected: 4 });
+  };
+
   const validStatus4Postpone = [TR.ASIGNANDO_VEHICULO, TR.ESPERANDO_PROVEEDOR];
 
   return (
@@ -176,6 +183,12 @@ export default function ModalGenerateActionOrders(props: Readonly<PropsModalGene
               : "Eliminar servicio"
           }
           onClick={handleDeleteOrders}
+        />
+        <ButtonGenerateAction
+          disabled={allSelectedRows?.length === 0}
+          icon={<Plus size={20} />}
+          title="Añadir TO a TR en curso"
+          onClick={handleAddToOngoingTR}
         />
       </Flex>
     </Modal>

--- a/src/components/molecules/modals/ModalPostponeTR/ModalPostponeTR.tsx
+++ b/src/components/molecules/modals/ModalPostponeTR/ModalPostponeTR.tsx
@@ -61,8 +61,6 @@ export const ModalPostponeTR = ({ isOpen, onCancel, onClose, allSelectedRows }: 
   const onPostponeTR = async (data: IFormModalPostponeTR) => {
     setLoading(true);
 
-    console.log("data", data);
-
     try {
       await postponeTR(
         allSelectedRows?.map((row) => Number(row.tr)) ?? [],

--- a/src/components/organisms/logistics/transfer-orders/TransferOrders.tsx
+++ b/src/components/organisms/logistics/transfer-orders/TransferOrders.tsx
@@ -21,6 +21,7 @@ import Filter from "@/components/atoms/Filters/FilterOrders";
 import { ModalCancelTR } from "@/components/molecules/modals/ModalCancelTR/ModalCancelTR";
 import { DataTypeForTransferOrderTable } from "@/components/molecules/tables/TransferOrderTable/TransferOrderTable";
 import { ModalPostponeTR } from "@/components/molecules/modals/ModalPostponeTR/ModalPostponeTR";
+import { ModalAddTR2TO } from "@/components/molecules/modals/ModalAddTR2TO/ModalAddTR2TO";
 
 import styles from "./transferOrders.module.scss";
 
@@ -291,6 +292,21 @@ export const TransferOrders = () => {
 
         <ModalPostponeTR
           isOpen={isModalOpen.selected === 3}
+          onCancel={() => setIsModalOpen({ selected: 1 })}
+          onClose={() => {
+            setOrdersId([]);
+            setTrsIds([]);
+            setChildOrdersId([]);
+            setAllSelectedRows([]);
+
+            setMutate((prev) => !prev);
+            setIsModalOpen({ selected: 0 });
+          }}
+          allSelectedRows={allSelectedRows}
+        />
+
+        <ModalAddTR2TO
+          isOpen={isModalOpen.selected === 4}
           onCancel={() => setIsModalOpen({ selected: 1 })}
           onClose={() => {
             setOrdersId([]);

--- a/src/services/logistics/transfer-request.ts
+++ b/src/services/logistics/transfer-request.ts
@@ -422,3 +422,23 @@ export const getModifyOptions = async (): Promise<IModifyOption[]> => {
     return error as any;
   }
 };
+
+export const addTOToOngoingTR = async (
+  transferOrderId: number,
+  transferRequestId: number
+): Promise<any> => {
+  const body = {
+    id_tr: transferRequestId,
+    id_to: transferOrderId
+  };
+  try {
+    const response: GenericResponse<any> = await API.post(`transfer-request/add-to-in-tr`, body);
+    if (response.success) return response.data;
+    throw new Error(
+      response?.message || "Error al agregar la orden de transferencia a la TR en curso"
+    );
+  } catch (error) {
+    console.error("Error addTOToOngoingTR: ", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
<img width="1178" height="915" alt="image" src="https://github.com/user-attachments/assets/9ce136a8-dbc0-43d4-be67-7b9493136950" />

This pull request introduces the ability to add a Transfer Order (TO) to an ongoing Transfer Request (TR) directly from the UI. It includes a new modal for this action, integrates it into the transfer orders workflow, and implements the corresponding backend service call. Additionally, some minor code cleanups and UI improvements are included.

**New Feature: Add TO to Ongoing TR**

- **Modal and UI Integration:**
  - Added a new modal component `ModalAddTR2TO` that allows users to input a TR ID and add the selected TO to an ongoing TR. The modal includes validation, loading state, and success/error messaging. (`src/components/molecules/modals/ModalAddTR2TO/ModalAddTR2TO.tsx`, `src/components/molecules/modals/ModalAddTR2TO/modalAddTR2TO.scss`) [[1]](diffhunk://#diff-b58c72901038a074574a27e4c5f7b473c92eb4a4e30fcdaa51e657330f0238b0R1-R114) [[2]](diffhunk://#diff-9ff6ae75cabf64797fcfe68abc0131462f0f6ca6e466006e6fe45e5f4e06b64dR1-R11)
  - Integrated the new modal into the `TransferOrders` page, including state management for opening/closing and refreshing data after a successful operation. (`src/components/organisms/logistics/transfer-orders/TransferOrders.tsx`) [[1]](diffhunk://#diff-721deb4c84fbec1bf978dd4470ed94d6d47d3d02371aa7bb1b2920b1545c23edR24) [[2]](diffhunk://#diff-721deb4c84fbec1bf978dd4470ed94d6d47d3d02371aa7bb1b2920b1545c23edR307-R321)
  - Added a new action button ("Añadir TO a TR en curso") to the action bar in `ModalGenerateActionOrders`, which opens the new modal. Button is disabled if no rows are selected and enforces single selection. (`src/components/molecules/modals/ModalGenerateActionOrders/ModalGenerateActionOrders.tsx`) [[1]](diffhunk://#diff-8d68ab027c53d8dcb875840325e6d34cbb3c4c7999162915d92faa98e1251854L5-R5) [[2]](diffhunk://#diff-8d68ab027c53d8dcb875840325e6d34cbb3c4c7999162915d92faa98e1251854R94-R100) [[3]](diffhunk://#diff-8d68ab027c53d8dcb875840325e6d34cbb3c4c7999162915d92faa98e1251854R187-R192)

**Backend Integration**

- **Service Method:**
  - Implemented `addTOToOngoingTR` service function to call the backend API for adding a TO to an ongoing TR, with error handling and response validation. (`src/services/logistics/transfer-request.ts`)

**Other Improvements**

- **Minor Cleanups:**
  - Removed unnecessary console log from the TR postponement modal. (`src/components/molecules/modals/ModalPostponeTR/ModalPostponeTR.tsx`)
  - Added basic SCSS for the new modal for improved UI consistency. (`src/components/molecules/modals/ModalAddTR2TO/modalAddTR2TO.scss`)