### PR TITLE
Fix/86dyk3pd0/tercerizacion y licitacion select

### DIFF
--- a/src/components/molecules/tables/CarrierTable/CarrierTable.tsx
+++ b/src/components/molecules/tables/CarrierTable/CarrierTable.tsx
@@ -139,7 +139,13 @@ export default function CarrierTable({
       dataIndex: "amount",
       render: (amount, row) => (
         <Text style={{ fontWeight: 600, whiteSpace: "nowrap" }}>
-          {!row.isAuction ? (amount ? formatMoney(amount) : "$ 0") : "Cotización"}
+          {row.isAuction === 1
+            ? "Cotización"
+            : row.isAuction === 2
+              ? "Tercerización"
+              : amount
+                ? formatMoney(amount)
+                : "$ 0"}
         </Text>
       ),
       sorter: (a, b) => a.amount - b.amount,

--- a/src/components/organisms/logistics/orders/transfer_request/components/modals/ModalSelectTender.tsx
+++ b/src/components/organisms/logistics/orders/transfer_request/components/modals/ModalSelectTender.tsx
@@ -61,14 +61,12 @@ export default function ModalSelectTender({ open, handleModalTender, type }: Rea
   );
 
   const { data, isLoading, isValidating } = useSWR(
-    { idTransferRequest: id, open },
-    ({ idTransferRequest, open }) =>
-      open ? getTransferRequestPricing({ idTransferRequest }) : undefined,
+    open ? `/transfer-request/pricing/${id}` : null,
+    () => getTransferRequestPricing({ idTransferRequest: id }),
     {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
-      revalidateIfStale: true,
-      revalidateOnMount: false
+      revalidateIfStale: false
     }
   );
 

--- a/src/types/logistics/carrier/carrier.ts
+++ b/src/types/logistics/carrier/carrier.ts
@@ -186,7 +186,7 @@ export interface CarrierRequestAPI {
   amount: number; // Monto asociado al servicio
   order_nro: number; // Número de orden
   id_transfer_request: number; // ID de la solicitud de transferencia
-  isAuction: boolean;
+  isAuction: number;
 }
 
 export interface CarrierCollapseAPI {


### PR DESCRIPTION
<img width="1468" height="984" alt="image" src="https://github.com/user-attachments/assets/6a974410-5f55-4cf6-9ff7-2c3bf3957421" />
This pull request updates the handling of the `isAuction` property for carriers, improves the display logic in the `CarrierTable`, and refactors the data fetching logic in the transfer request modal. The most important changes are grouped below:

**Carrier Auction Property Handling:**

* Changed the type of `isAuction` from `boolean` to `number` in the `CarrierRequestAPI` interface in `carrier.ts`, allowing for more than two states (e.g., standard, auction, outsourcing).

**Carrier Table Display Logic:**

* Updated the `CarrierTable` component to display "Cotización" when `isAuction` is `1`, "Tercerización" when `isAuction` is `2`, and otherwise formats the amount or shows "$ 0". This supports the new multi-state `isAuction` logic.

**Transfer Request Modal Data Fetching:**

* Refactored the `useSWR` hook in `ModalSelectTender` to use a simpler key (`/transfer-request/pricing/${id}`) and fetcher function, and adjusted revalidation options for more predictable data fetching.
