### PR TITLE
Fix date formatting to use UTC methods in formatDate function

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -159,9 +159,9 @@ export function extractSingleParam(value: string | string[] | undefined): string
 
 export function formatDate(dateString: string): string {
   const date = new Date(dateString);
-  const day = String(date.getDate()).padStart(2, "0");
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const year = date.getFullYear();
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const year = date.getUTCFullYear();
 
   return `${day}/${month}/${year}`;
 }


### PR DESCRIPTION
This pull request updates the date formatting logic to ensure all dates are displayed in UTC rather than local time. This change helps maintain consistency across different user time zones.

Date formatting update:
* In `src/utils/utils.ts`, the `formatDate` function now uses UTC-based date methods (`getUTCDate`, `getUTCMonth`, `getUTCFullYear`) instead of local time methods, ensuring dates are formatted consistently regardless of the user's locale.