### PR TITLE
Use '1' for proveedorRecomendado checks

### DIFF
--- a/src/modules/logistics/approval/components/ValidationQuestions/CommonApprovalQuestions.tsx
+++ b/src/modules/logistics/approval/components/ValidationQuestions/CommonApprovalQuestions.tsx
@@ -130,7 +130,7 @@ export function CommonApprovalQuestions({
           )}
         />
 
-        {proveedorRecomendado === "si" && (
+        {proveedorRecomendado === "1" && (
           <div className="mt-4 p-4 bg-gray-50 rounded-lg border border-gray-200">
             <Label
               htmlFor={`emailConfirmacion-${idPrefix}`}

--- a/src/modules/logistics/approval/schemas/approvalFormSchema.ts
+++ b/src/modules/logistics/approval/schemas/approvalFormSchema.ts
@@ -37,7 +37,7 @@ export const approvalFormSchema = yup.object({
     .nullable()
     .when(["tipoAprobacion", "proveedorRecomendado"], {
       is: (tipo: string, recomendado: string) =>
-        (tipo === "viaje-especifico" || tipo === "tarifa-recurrente") && recomendado === "si",
+        (tipo === "viaje-especifico" || tipo === "tarifa-recurrente") && recomendado === "1",
       then: (schema) =>
         schema.test(
           "required-file",


### PR DESCRIPTION
Align conditional checks for proveedorRecomendado to use the string "1" instead of "si". Updated CommonApprovalQuestions.tsx to render the recommended-provider block when proveedorRecomendado === "1" and updated approvalFormSchema.ts to apply the file-required validation when proveedorRecomendado === "1". This keeps rendering and validation consistent with the actual form value.