### PR TITLE
Handle 3-state sustainability recommendation

### DIFF
--- a/src/components/organisms/TaskManager/TaskManagerDetailView/index.tsx
+++ b/src/components/organisms/TaskManager/TaskManagerDetailView/index.tsx
@@ -266,11 +266,20 @@ const TaskManagerDetailView = ({ moduleTitle, approvalId, onBack }: TaskManagerD
               <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                 <div
                   style={{
-                    color: approval.is_provider_recommended_by_sustainability ? "green" : "red",
+                    color:
+                      approval.is_provider_recommended_by_sustainability === 2
+                        ? "gray"
+                        : approval.is_provider_recommended_by_sustainability === 1
+                          ? "green"
+                          : "red",
                     fontWeight: 600
                   }}
                 >
-                  {approval.is_provider_recommended_by_sustainability ? "Sí" : "No"}
+                  {approval.is_provider_recommended_by_sustainability === 2
+                    ? "No aplica"
+                    : approval.is_provider_recommended_by_sustainability === 1
+                      ? "Sí"
+                      : "No"}
                 </div>
                 {approval.evidence_file_url && (
                   <Button

--- a/src/types/tasks/ITasks.ts
+++ b/src/types/tasks/ITasks.ts
@@ -77,7 +77,7 @@ export interface ITaskApproval {
   evidence_file_name?: string;
   send_single_source: number;
   is_another_contract_active: number;
-  is_provider_recommended_by_sustainability: number;
+  is_provider_recommended_by_sustainability: 0 | 1 | 2;
   tercerization_motive?: string | null;
   exists_another_provider_in_zone: number;
   subcontractor_ensure: number;


### PR DESCRIPTION
Update ITaskApproval to use a 0|1|2 union for is_provider_recommended_by_sustainability and adjust the detail view UI to handle the tri-state value. The component now maps 1 -> green "Sí", 0 -> red "No", and 2 -> gray "No aplica" instead of relying on a boolean truthy check, improving type safety and clarifying the "not applicable" state in the UI.