### PR TITLE
feat(tasks): add pagination to task manager list

### DIFF
--- a/src/components/organisms/TaskManager/TaskManagerTable/index.tsx
+++ b/src/components/organisms/TaskManager/TaskManagerTable/index.tsx
@@ -217,7 +217,7 @@ const TaskTable: React.FC<{
       dataSource={data?.map((task) => ({ ...task, key: task.id }))}
       rowSelection={rowSelection}
       pagination={false}
-      scroll={{ y: (height ?? 800) - 270, x: 100 }}
+      scroll={{ y: (height ?? 800) - 290, x: 100 }}
     />
   );
 };

--- a/src/components/organisms/TaskManager/TaskManagerView/index.tsx
+++ b/src/components/organisms/TaskManager/TaskManagerView/index.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { useState } from "react";
-import { Flex, Spin } from "antd";
+import { useEffect, useState } from "react";
+import { Flex, Pagination, Spin } from "antd";
 
 import UiSearchInput from "@/components/ui/search-input";
 import Container from "@/components/atoms/Container/Container";
@@ -15,13 +15,18 @@ import { useTasks } from "@/hooks/useTasks";
 
 const TaskManagerView = () => {
   const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
   const [selectedRows, setSelectedRows] = useState<ITask[] | undefined>(undefined);
   const [selectedFilters, setSelectedFilters] = useState<ISelectFilterTasks>({
     statuses: [],
     taskTypes: []
   });
 
-  const { data, isLoading } = useTasks(selectedFilters, search);
+  useEffect(() => {
+    setPage(1);
+  }, [search, selectedFilters]);
+
+  const { data, pagination, isLoading } = useTasks(selectedFilters, search, page);
 
   return (
     <div style={{ overflowY: "auto" }}>
@@ -45,10 +50,19 @@ const TaskManagerView = () => {
               <Spin />
             </Flex>
           ) : (
-            <TaskTable
-              data={data}
-              setSelectedRows={setSelectedRows}
-            />
+            <TaskTable data={data} setSelectedRows={setSelectedRows} />
+          )}
+
+          {pagination && (
+            <Flex justify="end" style={{ paddingBottom: "0.5rem" }}>
+              <Pagination
+                current={page}
+                pageSize={pagination.rowsperpage}
+                total={pagination.totalRows}
+                onChange={(newPage) => setPage(newPage)}
+                showSizeChanger={false}
+              />
+            </Flex>
           )}
         </Flex>
       </Container>

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,11 +1,22 @@
 import useSWR from "swr";
 import { fetcher } from "@/utils/api/api";
-import { GenericResponse } from "@/types/global/IGlobal";
+import { GenericResponsePage } from "@/types/global/IGlobal";
 import { ITask } from "@/types/tasks/ITasks";
 import { ISelectFilterTasks } from "@/components/atoms/Filters/FiltersTasks/FiltersTasks";
 
-export const useTasks = (filters: ISelectFilterTasks, searchQuery: string) => {
+export const useTasks = (
+  filters: ISelectFilterTasks,
+  searchQuery: string,
+  page: number = 1,
+  limit: number = 20
+) => {
   const queryParams: string[] = [];
+
+  queryParams.push(`page=${page}`);
+
+  if (limit) {
+    queryParams.push(`rowsPerPage=${limit}`);
+  }
 
   if (searchQuery) {
     queryParams.push(`searchQuery=${searchQuery}`);
@@ -21,12 +32,13 @@ export const useTasks = (filters: ISelectFilterTasks, searchQuery: string) => {
     queryParams.push(`taskType=${taskTypesParam}`);
   }
 
-  const requestUrl = "/task/get-all" + (queryParams.length > 0 ? `?${queryParams.join("&")}` : "");
+  const requestUrl = `/task/get-all?${queryParams.join("&")}`;
 
-  const { data, isLoading, mutate } = useSWR<GenericResponse<ITask[]>>(requestUrl, fetcher);
+  const { data, isLoading, mutate } = useSWR<GenericResponsePage<ITask[]>>(requestUrl, fetcher);
 
   return {
     data: data?.data || [],
+    pagination: data?.pagination,
     isLoading,
     mutate
   };


### PR DESCRIPTION
- Added Pagination component to TaskManagerView with page size and total rows
- Modified useTasks hook to accept page and limit parameters for paginated requests
- Added pagination state management with reset on search/filter changes
- Adjusted table scroll area to accommodate pagination controls
- Updated response type to include pagination metadata